### PR TITLE
Allow preserving window size & centering

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,8 @@ There are a couple of options:
 - Download the latest release from the [releases page](https://github.com/flyingpie/windows-terminal-quake/releases).
 - Clone/download the source and run **build.ps1**.
 - Clone/download the source and build using Visual Studio.
+
+## Options
+
+- Command line option "maximize" to always maximize the terminal window
+- Command line option "center" to always center the terminal window horizontally

--- a/windows-terminal-quake/Native/HotKeyManager.cs
+++ b/windows-terminal-quake/Native/HotKeyManager.cs
@@ -23,7 +23,7 @@ namespace WindowsTerminalQuake.Native
         }
 
         private delegate void RegisterHotKeyDelegate(IntPtr hwnd, int id, uint modifiers, uint key);
-
+        
         private delegate void UnRegisterHotKeyDelegate(IntPtr hwnd, int id);
 
         private static void RegisterHotKeyInternal(IntPtr hwnd, int id, uint modifiers, uint key)

--- a/windows-terminal-quake/Native/User32.cs
+++ b/windows-terminal-quake/Native/User32.cs
@@ -23,6 +23,9 @@ namespace WindowsTerminalQuake.Native
         [DllImport("user32.dll")]
         public static extern bool GetWindowRect(IntPtr hwnd, ref Rect rectangle);
 
+        [DllImport("user32.dll", CharSet = CharSet.Auto, ExactSpelling = true)]
+        public static extern IntPtr GetForegroundWindow();
+
         public struct Rect
         {
             public int Left { get; set; }

--- a/windows-terminal-quake/Program.cs
+++ b/windows-terminal-quake/Program.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
 using System.Threading;
+using WindowsTerminalQuake.Native;
 using WindowsTerminalQuake.UI;
 
 namespace WindowsTerminalQuake
@@ -14,6 +15,13 @@ namespace WindowsTerminalQuake
 
         public static void Main(string[] args)
         {
+            // don't allow more than one instance to be running simultaneously
+            var existingProcesses = Process.GetProcessesByName("windows-terminal-quake").Count();
+            if (existingProcesses > 1)
+            {
+                return;
+            }
+
             Application.ApplicationExit += (sender, e) =>
             {
                 Close();

--- a/windows-terminal-quake/Program.cs
+++ b/windows-terminal-quake/Program.cs
@@ -16,9 +16,17 @@ namespace WindowsTerminalQuake
         public static void Main(string[] args)
         {
             // don't allow more than one instance to be running simultaneously
-            var existingProcesses = Process.GetProcessesByName("windows-terminal-quake").Count();
-            if (existingProcesses > 1)
+            var existingProcesses = Process.GetProcessesByName("windows-terminal-quake");
+            if (existingProcesses.Count() > 1)
             {
+                try
+                {
+                    var process = GetWindowsTerminalProcess();
+                    if (process != null)
+                    {
+                        User32.SetForegroundWindow(process.MainWindowHandle);
+                    }
+                } catch (Exception) { }
                 return;
             }
 
@@ -37,53 +45,62 @@ namespace WindowsTerminalQuake
 
             try
             {
-                var processes = Process.GetProcessesByName("WindowsTerminal").Where(e => e.MainWindowHandle != default(IntPtr)).ToArray();
-                Process process = null;
-                int i = 0;
-                while (i < processes.Length)
-                {
-                    try
-                    {
-                        process = processes[i];
-                        bindProcessEvents(process);
-                        break;
-                    } catch (Exception)
-                    {
-                        i++;
-                    }
-                }
 
+                var process = GetWindowsTerminalProcess();
                 if (process == null)
                 {
-                    process = new Process
-                    {
-                        StartInfo = new ProcessStartInfo
-                        {
-                            FileName = "wt",
-                            UseShellExecute = false,
-                            RedirectStandardOutput = true,
-                            WindowStyle = config.Maximize ? ProcessWindowStyle.Maximized : ProcessWindowStyle.Hidden,
-                        }
-                    };
-                    process.Start();
-                    while (process.MainWindowTitle == ""  || process.MainWindowTitle == "DesktopWindowXamlSource")
-                    {
-                        Thread.Sleep(10);
-                        process.Refresh();
-                    }
-                    bindProcessEvents(process);
+                    process = CreateWindowsTerminalProcess(config);
                 }
-
                 _toggler = new Toggler(process, config);
-
                 _trayIcon.Notify(ToolTipIcon.Info, $"Windows Terminal Quake is running, press CTRL+~ or CTRL+Q to toggle.");
             }
             catch (Exception ex)
             {
                 _trayIcon.Notify(ToolTipIcon.Error, $"Cannot start: '{ex.Message}'.");
-
                 Close();
             }
+            
+        }
+        private static Process GetWindowsTerminalProcess()
+        {
+            var processes = Process.GetProcessesByName("WindowsTerminal").Where(e => e.MainWindowHandle != default(IntPtr)).ToArray();
+            Process process = null;
+            int i = 0;
+            while (i < processes.Length)
+            {
+                try
+                {
+                    process = processes[i];
+                    bindProcessEvents(process);
+                    break;
+                }
+                catch (Exception)
+                {
+                    i++;
+                }
+            }
+            return process;
+        }
+        private static Process CreateWindowsTerminalProcess(Config config)
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = "wt",
+                    UseShellExecute = false,
+                    RedirectStandardOutput = true,
+                    WindowStyle = config.Maximize ? ProcessWindowStyle.Maximized : ProcessWindowStyle.Hidden,
+                }
+            };
+            process.Start();
+            while (process.MainWindowTitle == "" || process.MainWindowTitle == "DesktopWindowXamlSource")
+            {
+                Thread.Sleep(10);
+                process.Refresh();
+            }
+            bindProcessEvents(process);
+            return process;
         }
 
         private static void bindProcessEvents(Process process)

--- a/windows-terminal-quake/TerminalWindow.cs
+++ b/windows-terminal-quake/TerminalWindow.cs
@@ -141,5 +141,16 @@ namespace WindowsTerminalQuake
             }
             Top = 0;
         }
+        public void EnsureWillFitOnScreen()
+        {
+            if (Height > _bounds.Height)
+            {
+                Height = _bounds.Height;
+            }
+            if (Width > _bounds.Width)
+            {
+                Width = _bounds.Width;
+            }
+        }
     }
 }

--- a/windows-terminal-quake/TerminalWindow.cs
+++ b/windows-terminal-quake/TerminalWindow.cs
@@ -1,0 +1,145 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using WindowsTerminalQuake.Native;
+
+namespace WindowsTerminalQuake
+{
+    class TerminalWindow
+    {
+        public const int MinWidth = 400;
+        public const int MinHeight = 120;
+        public const int DefaultWidth = 800;
+        public const int DefaultHeight = 400;
+
+        private User32.Rect _rect;
+        private System.Drawing.Rectangle _bounds;
+        public int Width
+        {
+            get
+            {
+                return this._rect.Right - this._rect.Left;
+            }
+            set
+            {
+                this._rect.Right = Math.Min(value + this._rect.Left, this._bounds.Width);
+            }
+        }
+        public int Height
+        {
+            get
+            {
+                return this._rect.Bottom - this._rect.Top;
+            }
+            set
+            {
+                this._rect.Bottom = Math.Min(value + this._rect.Top, this._bounds.Height);
+            }
+        }
+        public int Top {
+            get 
+            {
+                return Math.Min(this._rect.Top, this._bounds.Height - this.Height);
+            } 
+            set
+            {
+                var height = this.Height;
+                this._rect.Top = value;
+                this.Height = height;
+            }
+        }
+        public int Left { 
+            get
+            {
+                return Math.Min(this._rect.Left, this._bounds.Width - this.Width);
+            } 
+            set
+            {
+                var width = this.Width;
+                this._rect.Left = value;
+                this.Width = width;
+            }
+        }
+        public int ScreenX
+        {
+            get
+            {
+                return Left + _bounds.X;
+            }
+        }
+        public int ScreenY
+        {
+            get
+            {
+                return Top + _bounds.Y;
+            }
+        }
+
+        public TerminalWindow(User32.Rect rect, System.Drawing.Rectangle bounds)
+        {
+            this._rect = new User32.Rect
+            {
+                Left = rect.Left,
+                Right = rect.Right,
+                Top = rect.Top,
+                Bottom = rect.Bottom
+            };
+            this._bounds = new System.Drawing.Rectangle(bounds.X, bounds.Y, bounds.Width, bounds.Height);
+        }
+
+        public void CenterHorizontally()
+        {
+            this.Left = (int)Math.Floor((this._bounds.Width - this.Width) / 2.0);
+        }
+
+        public void FitWidth()
+        {
+            this._rect.Left = 0;
+            this._rect.Right = this._bounds.Width;
+        }
+
+        public bool IsMaximized()
+        {
+            return this.Top <= 0 && this.Left <= 0 && this.Height >= _bounds.Height && this.Width >= _bounds.Width;
+        }
+        public void Maximize()
+        {
+            this.Left = 0;
+            this.Top = 0;
+            this.Width = _bounds.Width;
+            this.Height = _bounds.Height;
+        }
+        public bool IsVisible()
+        {
+            // when minimizing, the window seems to still be within the screen bounary, but very small. Just checking it's within
+            // bounds is incorrect sometimes; so we also compare to a minimum size
+            return Top < _bounds.Height &&
+                Top + Height > 0 &&
+                Left < _bounds.Width &&
+                Left + Width > 0 &&
+                Width >= MinWidth &&
+                Height >= MinHeight;
+        }
+
+        public bool IsDocked()
+        {
+            return Top <= 0;
+        }
+        public void EnsureVisible()
+        {
+            if (Height <= MinHeight || Width <= MinWidth) {
+                // ensure visible if it got hidden
+                Height = DefaultHeight;
+                Width = DefaultWidth;
+                CenterHorizontally();
+            }
+            if (Left + Width <= 0)
+            {
+                CenterHorizontally();
+            }
+            Top = 0;
+        }
+    }
+}

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -58,9 +58,19 @@ namespace WindowsTerminalQuake
             User32.GetWindowRect(_process.MainWindowHandle, ref rect);
             var terminalWindow = new TerminalWindow(rect, GetScreenWithCursor().Bounds);
 
-            if (terminalWindow.IsVisible() && terminalWindow.IsDocked())
+            var isVisible = terminalWindow.IsVisible();
+            var isDocked = terminalWindow.IsDocked();
+
+            var foregroundWindow = Native.User32.GetForegroundWindow();
+            var isForeground = foregroundWindow == _process.MainWindowHandle;
+
+            if (isVisible && isDocked && isForeground)
             {
                 HideTerminalWithEffects(terminalWindow);
+            }
+            else if (isVisible && isDocked)
+            {
+                User32.SetForegroundWindow(_process.MainWindowHandle);
             }
             else
             {
@@ -142,6 +152,17 @@ namespace WindowsTerminalQuake
 
                 Task.Delay(1).GetAwaiter().GetResult();
             }
+            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.SHOW);
+        }
+        private void ShowProcessWindow(TerminalWindow terminalWindow) {
+            User32.MoveWindow(
+                 _process.MainWindowHandle,
+                 terminalWindow.ScreenX,
+                 terminalWindow.ScreenY,
+                 terminalWindow.Width,
+                 terminalWindow.Height,
+                 true
+            );
             User32.ShowWindow(_process.MainWindowHandle, NCmdShow.SHOW);
         }
 

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -7,76 +7,157 @@ using WindowsTerminalQuake.Native;
 
 namespace WindowsTerminalQuake
 {
+
     public class Toggler : IDisposable
     {
+        private static int offsetLeft = 0;
+        private static int width = 0;
+        private static int height = 0;
+
+        private static readonly int stepCount = 10;
+
         private Process _process;
-      
-        public Toggler(Process process)
+        private Config _config;
+
+        public Toggler(Process process, Config config)
         {
             _process = process;
+            _config = config;
 
             // Hide from taskbar
             User32.SetWindowLong(_process.MainWindowHandle, User32.GWL_EX_STYLE, (User32.GetWindowLong(_process.MainWindowHandle, User32.GWL_EX_STYLE) | User32.WS_EX_TOOLWINDOW) & ~User32.WS_EX_APPWINDOW);
 
-            User32.Rect rect = default;
-            var ok = User32.GetWindowRect(_process.MainWindowHandle, ref rect);
-            var isOpen = rect.Top >= GetScreenWithCursor().Bounds.Y;
-            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MAXIMIZE);
+            if (config.Maximize)
+            {
+                User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MAXIMIZE);
+            }
 
-            var stepCount = 10;
+            User32.Rect rect = default;
+            User32.GetWindowRect(_process.MainWindowHandle, ref rect);
+            var terminalWindow = new TerminalWindow(rect, GetScreenWithCursor().Bounds);
+            if (config.Center)
+            {
+                terminalWindow.CenterHorizontally();
+            }
+            terminalWindow.EnsureVisible();
+            SaveTerminalState(terminalWindow);
+
+            User32.MoveWindow(_process.MainWindowHandle, terminalWindow.ScreenX, terminalWindow.ScreenY, terminalWindow.Width, terminalWindow.Height, true);
+            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.SHOW);
+            User32.SetForegroundWindow(_process.MainWindowHandle);
 
             HotKeyManager.RegisterHotKey(Keys.Oemtilde, KeyModifiers.Control);
             HotKeyManager.RegisterHotKey(Keys.Q, KeyModifiers.Control);
 
-            HotKeyManager.HotKeyPressed += (s, a) =>
-            {
-                if (isOpen)
-                {
-                    isOpen = false;
-                    Console.WriteLine("Close");
-
-                    User32.ShowWindow(_process.MainWindowHandle, NCmdShow.RESTORE);
-                    User32.SetForegroundWindow(_process.MainWindowHandle);
-
-                    var bounds = GetScreenWithCursor().Bounds;
-
-                    for (int i = stepCount - 1; i >= 0; i--)
-                    {
-                        User32.MoveWindow(_process.MainWindowHandle, bounds.X, bounds.Y + (-bounds.Height + (bounds.Height / stepCount * i)), bounds.Width, bounds.Height, true);
-
-                        Task.Delay(1).GetAwaiter().GetResult();
-                    }
-
-                    // Minimize, so the last window gets focus
-                    User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MINIMIZE);
-
-                    // Hide, so the terminal windows doesn't linger on the desktop
-                    User32.ShowWindow(_process.MainWindowHandle, NCmdShow.HIDE);
-                }
-                else
-                {
-                    isOpen = true;
-                    Console.WriteLine("Open");
-
-                    User32.ShowWindow(_process.MainWindowHandle, NCmdShow.RESTORE);
-                    User32.SetForegroundWindow(_process.MainWindowHandle);
-
-                    var bounds = GetScreenWithCursor().Bounds;
-
-                    for (int i = 1; i <= stepCount; i++)
-                    {
-                        User32.MoveWindow(_process.MainWindowHandle, bounds.X, bounds.Y + (-bounds.Height + (bounds.Height / stepCount * i)), bounds.Width, bounds.Height, true);
-
-                        Task.Delay(1).GetAwaiter().GetResult();
-                    }
-                    User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MAXIMIZE);
-                }
-            };
+            HotKeyManager.HotKeyPressed += handleHotKeyPressed;
         }
 
-        public void Dispose()
+        private void handleHotKeyPressed(object e, HotKeyEventArgs a)
         {
-            ResetTerminal(_process);
+            User32.Rect rect = default;
+            User32.GetWindowRect(_process.MainWindowHandle, ref rect);
+            var terminalWindow = new TerminalWindow(rect, GetScreenWithCursor().Bounds);
+
+            if (terminalWindow.IsVisible() && terminalWindow.IsDocked())
+            {
+                HideTerminalWithEffects(terminalWindow);
+            }
+            else
+            {
+                ShowTerminalWithEffects(terminalWindow);
+            }
+        }
+
+        private void HideTerminalWithEffects(TerminalWindow terminalWindow)
+        {
+            SaveTerminalState(terminalWindow);
+
+            if (terminalWindow.Top > 0)
+            {
+                HideProcessWindow();
+                return;
+            }
+
+            Console.WriteLine("Close");
+
+            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.SHOW);
+            User32.SetForegroundWindow(_process.MainWindowHandle);
+
+            var stepSize = (double)height / (double)stepCount;
+            for (int i = 1; i <= stepCount; i++)
+            {
+
+                User32.MoveWindow(
+                    _process.MainWindowHandle, 
+                    terminalWindow.ScreenX, 
+                    terminalWindow.ScreenY - (int)Math.Round(stepSize * i), 
+                    terminalWindow.Width, 
+                    terminalWindow.Height, 
+                    true
+                );
+
+                Task.Delay(1).GetAwaiter().GetResult();
+            }
+
+            HideProcessWindow();
+        }
+
+        private void ShowTerminalWithEffects(TerminalWindow terminalWindow)
+        {
+            Console.WriteLine("Open");
+            terminalWindow.Left = offsetLeft;
+            terminalWindow.Width = width;
+            terminalWindow.Top = -height;
+            terminalWindow.Height = height;
+            terminalWindow.EnsureWillFitOnScreen();
+
+            if (_config.Center)
+            {
+                terminalWindow.CenterHorizontally();
+            }
+
+            User32.MoveWindow(
+                _process.MainWindowHandle,
+                terminalWindow.ScreenX,
+                terminalWindow.ScreenY - terminalWindow.Height,
+                terminalWindow.Width,
+                terminalWindow.Height,
+                false
+            );
+
+            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.RESTORE);
+            User32.SetForegroundWindow(_process.MainWindowHandle);
+
+            var stepSize = (double)height / (double)stepCount;
+            for (int i = 1; i <= stepCount; i++)
+            {
+                User32.MoveWindow(
+                    _process.MainWindowHandle,
+                    terminalWindow.ScreenX,
+                    terminalWindow.ScreenY + (int)Math.Round(stepSize * i),
+                    terminalWindow.Width,
+                    terminalWindow.Height,
+                    true
+                );
+
+                Task.Delay(1).GetAwaiter().GetResult();
+            }
+            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.SHOW);
+        }
+
+        private void HideProcessWindow() { 
+            // Minimize, so the last window gets focus
+            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MINIMIZE);
+
+            // Hide, so the terminal windows doesn't linger on the desktop
+            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.HIDE);
+        }
+
+        private void SaveTerminalState(TerminalWindow terminalWindow)
+        {
+            width = terminalWindow.Width;
+            height = terminalWindow.Height;
+            offsetLeft = terminalWindow.Left;
         }
 
         private static Screen GetScreenWithCursor()
@@ -84,18 +165,25 @@ namespace WindowsTerminalQuake
             return Screen.AllScreens.FirstOrDefault(s => s.Bounds.Contains(Cursor.Position));
         }
 
+        public void Dispose()
+        {
+            ResetTerminal(_process);
+        }
         private static void ResetTerminal(Process process)
         {
-            var bounds = GetScreenWithCursor().Bounds;
+            User32.Rect rect = default;
+            User32.GetWindowRect(process.MainWindowHandle, ref rect);
+
+            var terminalWindow = new TerminalWindow(rect, GetScreenWithCursor().Bounds);
 
             // Restore taskbar icon
             User32.SetWindowLong(process.MainWindowHandle, User32.GWL_EX_STYLE, (User32.GetWindowLong(process.MainWindowHandle, User32.GWL_EX_STYLE) | User32.WS_EX_TOOLWINDOW) & User32.WS_EX_APPWINDOW);
 
             // Reset position
-            User32.MoveWindow(process.MainWindowHandle, bounds.X, bounds.Y, bounds.Width, bounds.Height, true);
+            User32.MoveWindow(process.MainWindowHandle, terminalWindow.ScreenX, terminalWindow.ScreenY, terminalWindow.Width, terminalWindow.Height, true);
 
             // Restore window
-            User32.ShowWindow(process.MainWindowHandle, NCmdShow.MAXIMIZE);
+            User32.ShowWindow(process.MainWindowHandle, NCmdShow.SHOW);
         }
     }
 }

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -154,17 +154,6 @@ namespace WindowsTerminalQuake
             }
             User32.ShowWindow(_process.MainWindowHandle, NCmdShow.SHOW);
         }
-        private void ShowProcessWindow(TerminalWindow terminalWindow) {
-            User32.MoveWindow(
-                 _process.MainWindowHandle,
-                 terminalWindow.ScreenX,
-                 terminalWindow.ScreenY,
-                 terminalWindow.Width,
-                 terminalWindow.Height,
-                 true
-            );
-            User32.ShowWindow(_process.MainWindowHandle, NCmdShow.SHOW);
-        }
 
         private void HideProcessWindow() { 
             // Minimize, so the last window gets focus

--- a/windows-terminal-quake/config.cs
+++ b/windows-terminal-quake/config.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace WindowsTerminalQuake
+{
+    public class Config
+    {
+        public bool Maximize { get; set; }
+        public bool Center { get; set; }
+    }
+}


### PR DESCRIPTION
Hey! Thanks for this. I love the quake too, but I like my terminals to persist their size (rather than consuming the whole screen) and be centered, so I did a little work to support that in your application. 

Since this is a bit more complicated I did some refactoring to make it easier to deal with. Also, I know next to nothing about using the window API (basically followed your examples), so consider this pull request "hmm, here's a thought, take it or leave it, this code is probably garbage." But it seems to work and I thought others might like this addition.

If you like the idea/refactor and want to merge it -- or suggest changes -- awesome. If not totally fine too. I hope this whole necessity is fairly short lived and the feature becomes mainlined :)

The things that are different are:

- doesn't maximize by default any more (requires "maximize" cli option)
- when not maximizing, persist the size of the terminal at the time it was minimized
- tries to avoid ghost processes on startup & unclean exit (probably only useful during development, when they seem to accumulate, could be totally wrong)
- tries to wait until the process it's started has finished rendering so it can position it when it's ready
- makes sure window fits on screen before displaying

Thanks again. Neat app, I can finally be happy without ConEmu.
