### PR TITLE
Settings

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,19 +1,74 @@
 #tool "nuget:?package=vswhere&version=2.6.7"
+#tool "nuget:?package=ILRepack&version=2.0.18"
 
 var configuration = Argument("configuration", "Release");
+var output = Argument("output", "artifacts");
+var version = Argument("version", "v0.4");
 
 var sln = "windows-terminal-quake.sln";
+var bin = "./windows-terminal-quake/bin";
 
-Task("Default").Does(() =>
-{
-	NuGetRestore(sln);
-
-	MSBuild(sln, new MSBuildSettings
+Task("Clean")
+	.Does(() =>
 	{
-		Configuration = "Release",
-		Restore = true,
-		ToolPath = GetFiles(VSWhereLatest() + "/**/MSBuild.exe").FirstOrDefault()
+		CleanDirectory(output);
 	});
-});
+
+Task("Build")
+	.IsDependentOn("Clean")
+	.Does(() =>
+	{
+		MSBuild(sln, new MSBuildSettings
+		{
+			Configuration = "Release",
+			Restore = true,
+			ToolPath = GetFiles(VSWhereLatest() + "/**/MSBuild.exe").FirstOrDefault()
+		});
+	});
+
+Task("Artifact.Regular")
+	.IsDependentOn("Build")
+	.Does(() =>
+	{
+		var art = output + "/Artifact.Regular";
+		CopyDirectory(bin, art);
+		DeleteFiles(art + "/*.config");
+		DeleteFiles(art + "/*.pdb");
+	});
+
+Task("Artifact.SingleExe")
+	.IsDependentOn("Build")
+	.Does(() =>
+	{
+		var deps = GetFiles(bin + "/*.dll");
+		var art = output + "/Artifact.SingleExe";
+		System.IO.Directory.CreateDirectory(art);
+
+		ILRepack(
+			art + "/windows-terminal-quake.exe",		// Output file
+			bin + "/windows-terminal-quake.exe",		// Primary assembly
+			deps,															// Assembly paths
+			new ILRepackSettings()
+		);
+
+		CopyFile(bin + "/windows-terminal-quake.json", art + "/windows-terminal-quake.json");
+		DeleteFile(art + "/windows-terminal-quake.exe.config");
+	});
+
+Task("Artifact.SingleExe.Zip")
+	.IsDependentOn("Artifact.SingleExe")
+	.Does(() =>
+	{
+		var art = output + "/Artifact.SingleExe.Zip";
+		System.IO.Directory.CreateDirectory(art);
+
+		Zip(output + "/Artifact.SingleExe", art + $"/windows-terminal-quake-{version}-{DateTimeOffset.UtcNow:yyyy-MM-dd_HHmm}.zip");
+	});
+
+Task("Default")
+	.IsDependentOn("Artifact.Regular")
+	.IsDependentOn("Artifact.SingleExe")
+	.IsDependentOn("Artifact.SingleExe.Zip")
+	.Does(() => {});
 
 RunTarget("Default");

--- a/windows-terminal-quake/Logging.cs
+++ b/windows-terminal-quake/Logging.cs
@@ -1,0 +1,27 @@
+﻿using Serilog;
+using System;
+using System.IO;
+
+namespace WindowsTerminalQuake
+{
+	public static class Logging
+	{
+		public static void Configure()
+		{
+			var here = Path.GetDirectoryName(new Uri(typeof(Logging).Assembly.Location).AbsolutePath);
+
+			Log.Logger = new LoggerConfiguration()
+				.MinimumLevel.Is(Serilog.Events.LogEventLevel.Information)
+				.WriteTo.File(
+					path: Path.Combine(here, "logs/.txt"),
+					fileSizeLimitBytes: 10_000_000,
+					rollingInterval: RollingInterval.Day,
+					retainedFileCountLimit: 3
+				)
+				.CreateLogger()
+			;
+
+			Log.Information("Windows Terminal Quake started");
+		}
+	}
+}

--- a/windows-terminal-quake/Program.cs
+++ b/windows-terminal-quake/Program.cs
@@ -13,6 +13,8 @@ namespace WindowsTerminalQuake
 
 		public static void Main(string[] args)
 		{
+			Logging.Configure();
+
 			_trayIcon = new TrayIcon((s, a) => Close());
 
 			try
@@ -40,7 +42,9 @@ namespace WindowsTerminalQuake
 				};
 				_toggler = new Toggler(process);
 
-				_trayIcon.Notify(ToolTipIcon.Info, $"Windows Terminal Quake is running, press CTRL+~ or CTRL+Q to toggle.");
+				var hks = string.Join(" or ", Settings.Instance.Hotkeys.Select(hk => $"{hk.Modifiers}+{hk.Key}"));
+
+				_trayIcon.Notify(ToolTipIcon.Info, $"Windows Terminal Quake is running, press {hks} to toggle.");
 			}
 			catch (Exception ex)
 			{

--- a/windows-terminal-quake/Settings.cs
+++ b/windows-terminal-quake/Settings.cs
@@ -28,7 +28,8 @@ namespace WindowsTerminalQuake
 				new Hotkey() { Modifiers = KeyModifiers.Control, Key = Keys.Q }
 			},
 			Notifications = true,
-			ToggleDurationMs = 300
+			ToggleDurationMs = 250,
+			VerticalScreenCoverage = 100
 		};
 
 		private static readonly List<Action<SettingsDto>> _listeners = new List<Action<SettingsDto>>();
@@ -116,6 +117,8 @@ namespace WindowsTerminalQuake
 		public List<Hotkey> Hotkeys { get; set; }
 
 		public bool Notifications { get; set; }
+
+		public int VerticalScreenCoverage { get; set; }
 
 		public int ToggleDurationMs { get; set; }
 	}

--- a/windows-terminal-quake/Settings.cs
+++ b/windows-terminal-quake/Settings.cs
@@ -1,0 +1,129 @@
+﻿using Newtonsoft.Json;
+using Polly;
+using Polly.Retry;
+using Serilog;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Windows.Forms;
+using WindowsTerminalQuake.Native;
+using WindowsTerminalQuake.UI;
+
+namespace WindowsTerminalQuake
+{
+	public class Settings
+	{
+		public static readonly string[] PathsToSettings = new[]
+		{
+			Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "windows-terminal-quake.json"),
+			Path.Combine(Path.GetDirectoryName(new Uri(typeof(Settings).Assembly.Location).AbsolutePath), "windows-terminal-quake.json"),
+		};
+
+		public static SettingsDto Instance { get; private set; } = new SettingsDto() // Defaults
+		{
+			Hotkeys = new List<Hotkey>()
+			{
+				new Hotkey() { Modifiers = KeyModifiers.Control, Key = Keys.Oemtilde },
+				new Hotkey() { Modifiers = KeyModifiers.Control, Key = Keys.Q }
+			},
+			Notifications = true,
+			ToggleDurationMs = 300
+		};
+
+		private static readonly List<Action<SettingsDto>> _listeners = new List<Action<SettingsDto>>();
+
+		public static void Get(Action<SettingsDto> action)
+		{
+			_listeners.Add(action);
+
+			action(Instance);
+		}
+
+		#region Loading & Reloading
+
+		private static readonly RetryPolicy Retry = Policy
+			.Handle<Exception>()
+			.WaitAndRetry(new[] { TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1) })
+		;
+
+		private static readonly List<FileSystemWatcher> _fsWatchers;
+
+		static Settings()
+		{
+			_fsWatchers = PathsToSettings
+				.Select(path =>
+				{
+					Log.Information($"Watching settings file '{path}' for changes");
+					var fsWatcher = new FileSystemWatcher(Path.GetDirectoryName(path), Path.GetFileName(path));
+
+					fsWatcher.Changed += (s, a) =>
+					{
+						Log.Information($"Settings file '{a.FullPath}' changed");
+						Reload(true);
+					};
+
+					fsWatcher.EnableRaisingEvents = true;
+
+					return fsWatcher;
+				})
+				.ToList()
+			;
+
+			Application.ApplicationExit += (s, a) => _fsWatchers.ForEach(w => w.Dispose());
+
+			Reload(false);
+		}
+
+		public static void Reload(bool notify)
+		{
+			Retry.Execute(() =>
+			{
+				Log.Information("Reloading settings");
+
+				foreach (var pathToSettings in PathsToSettings)
+				{
+					if (!File.Exists(pathToSettings))
+					{
+						Log.Warning($"Settings file at '{pathToSettings}' does not exist");
+						continue;
+					}
+
+					Log.Information($"Found settings file at '{pathToSettings}'");
+
+					try
+					{
+						Instance = JsonConvert.DeserializeObject<SettingsDto>(File.ReadAllText(pathToSettings));
+						Log.Information($"Loaded settings from '{pathToSettings}'");
+						if (notify) TrayIcon.Instance.Notify(ToolTipIcon.Info, $"Loaded settings from '{pathToSettings}'");
+						break;
+					}
+					catch (Exception ex)
+					{
+						Log.Error($"Could not load settings from file '{pathToSettings}': {ex.Message}", ex);
+					}
+				}
+
+				_listeners.ForEach(l => l(Instance));
+			});
+		}
+
+		#endregion Loading & Reloading
+	}
+
+	public class SettingsDto
+	{
+		public List<Hotkey> Hotkeys { get; set; }
+
+		public bool Notifications { get; set; }
+
+		public int ToggleDurationMs { get; set; }
+	}
+
+	public class Hotkey
+	{
+		public KeyModifiers Modifiers { get; set; }
+
+		public Keys Key { get; set; }
+	}
+}

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -55,6 +55,7 @@ namespace WindowsTerminalQuake
 					User32.SetForegroundWindow(_process.MainWindowHandle);
 
 					var bounds = GetScreenWithCursor().Bounds;
+					bounds.Height = (int)Math.Ceiling((bounds.Height / 100f) * Settings.Instance.VerticalScreenCoverage);
 
 					for (int i = stepCount - 1; i >= 0; i--)
 					{
@@ -78,6 +79,7 @@ namespace WindowsTerminalQuake
 					User32.SetForegroundWindow(_process.MainWindowHandle);
 
 					var bounds = GetScreenWithCursor().Bounds;
+					bounds.Height = (int)Math.Ceiling((bounds.Height / 100f) * Settings.Instance.VerticalScreenCoverage);
 
 					for (int i = 1; i <= stepCount; i++)
 					{
@@ -85,7 +87,11 @@ namespace WindowsTerminalQuake
 
 						Task.Delay(TimeSpan.FromMilliseconds(stepDelayMs)).GetAwaiter().GetResult();
 					}
-					User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MAXIMIZE);
+
+					if (Settings.Instance.VerticalScreenCoverage == 100)
+					{
+						User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MAXIMIZE);
+					}
 				}
 			};
 		}

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -1,4 +1,6 @@
-﻿using System;
+﻿using Serilog;
+using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
@@ -10,6 +12,8 @@ namespace WindowsTerminalQuake
 	public class Toggler : IDisposable
 	{
 		private Process _process;
+
+		private readonly List<int> _registeredHotKeys = new List<int>();
 
 		public Toggler(Process process)
 		{
@@ -23,17 +27,29 @@ namespace WindowsTerminalQuake
 			var isOpen = rect.Top >= GetScreenWithCursor().Bounds.Y;
 			User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MAXIMIZE);
 
-			var stepCount = 10;
+			// Register hotkeys
+			Settings.Get(s =>
+			{
+				_registeredHotKeys.ForEach(hk => HotKeyManager.UnregisterHotKey(hk));
+				_registeredHotKeys.Clear();
 
-			HotKeyManager.RegisterHotKey(Keys.Oemtilde, KeyModifiers.Control);
-			HotKeyManager.RegisterHotKey(Keys.Q, KeyModifiers.Control);
+				s.Hotkeys.ForEach(hk =>
+				{
+					Log.Information($"Registering hot key {hk.Modifiers} + {hk.Key}");
+					var reg = HotKeyManager.RegisterHotKey(hk.Key, hk.Modifiers);
+					_registeredHotKeys.Add(reg);
+				});
+			});
 
 			HotKeyManager.HotKeyPressed += (s, a) =>
 			{
+				var stepCount = (int)Math.Max(Math.Ceiling(Settings.Instance.ToggleDurationMs / 25f), 1f);
+				var stepDelayMs = Settings.Instance.ToggleDurationMs / stepCount;
+
 				if (isOpen)
 				{
 					isOpen = false;
-					Console.WriteLine("Close");
+					Log.Information("Close");
 
 					User32.ShowWindow(_process.MainWindowHandle, NCmdShow.RESTORE);
 					User32.SetForegroundWindow(_process.MainWindowHandle);
@@ -44,7 +60,7 @@ namespace WindowsTerminalQuake
 					{
 						User32.MoveWindow(_process.MainWindowHandle, bounds.X, bounds.Y + (-bounds.Height + (bounds.Height / stepCount * i)), bounds.Width, bounds.Height, true);
 
-						Task.Delay(1).GetAwaiter().GetResult();
+						Task.Delay(TimeSpan.FromMilliseconds(stepDelayMs)).GetAwaiter().GetResult();
 					}
 
 					// Minimize, so the last window gets focus
@@ -56,7 +72,7 @@ namespace WindowsTerminalQuake
 				else
 				{
 					isOpen = true;
-					Console.WriteLine("Open");
+					Log.Information("Open");
 
 					User32.ShowWindow(_process.MainWindowHandle, NCmdShow.RESTORE);
 					User32.SetForegroundWindow(_process.MainWindowHandle);
@@ -67,7 +83,7 @@ namespace WindowsTerminalQuake
 					{
 						User32.MoveWindow(_process.MainWindowHandle, bounds.X, bounds.Y + (-bounds.Height + (bounds.Height / stepCount * i)), bounds.Width, bounds.Height, true);
 
-						Task.Delay(1).GetAwaiter().GetResult();
+						Task.Delay(TimeSpan.FromMilliseconds(stepDelayMs)).GetAwaiter().GetResult();
 					}
 					User32.ShowWindow(_process.MainWindowHandle, NCmdShow.MAXIMIZE);
 				}

--- a/windows-terminal-quake/UI/TrayIcon.cs
+++ b/windows-terminal-quake/UI/TrayIcon.cs
@@ -8,10 +8,14 @@ namespace WindowsTerminalQuake.UI
 {
 	public class TrayIcon : IDisposable
 	{
+		public static TrayIcon Instance { get; private set; }
+
 		private NotifyIcon _notificationIcon;
 
 		public TrayIcon(Action<object, EventArgs> exitHandler)
 		{
+			Instance = this;
+
 			var waiter = new TaskCompletionSource<bool>();
 
 			var notifyThread = new Thread(delegate ()
@@ -56,7 +60,10 @@ namespace WindowsTerminalQuake.UI
 
 		public void Notify(ToolTipIcon type, string message)
 		{
-			_notificationIcon.ShowBalloonTip(3, $"Windows Terminal", message, type);
+			if (Settings.Instance.Notifications)
+			{
+				_notificationIcon.ShowBalloonTip(3, $"Windows Terminal", message, type);
+			}
 		}
 
 		private static Icon CreateIcon()

--- a/windows-terminal-quake/windows-terminal-quake.csproj
+++ b/windows-terminal-quake/windows-terminal-quake.csproj
@@ -4,7 +4,7 @@
 		<OutputPath>bin</OutputPath>
 		<OutputType>WinExe</OutputType>
 		<TargetFramework>net472</TargetFramework>
-		<ApplicationIcon />
+		<ApplicationIcon>UI\icon.ico</ApplicationIcon>
 		<StartupObject />
 	</PropertyGroup>
 	<ItemGroup>

--- a/windows-terminal-quake/windows-terminal-quake.csproj
+++ b/windows-terminal-quake/windows-terminal-quake.csproj
@@ -7,6 +7,12 @@
 		<ApplicationIcon />
 		<StartupObject />
 	</PropertyGroup>
+	<ItemGroup>
+		<PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
+		<PackageReference Include="Polly" Version="7.2.1" />
+		<PackageReference Include="Serilog" Version="2.9.0" />
+		<PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+	</ItemGroup>
 
 	<ItemGroup>
 		<Reference Include="System.Windows.Forms" />
@@ -25,5 +31,11 @@
 			<Generator>ResXFileCodeGenerator</Generator>
 			<LastGenOutput>_Resources.Designer.cs</LastGenOutput>
 		</EmbeddedResource>
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Update="windows-terminal-quake.json">
+			<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+		</None>
 	</ItemGroup>
 </Project>

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -15,7 +15,10 @@
 	"Notifications": true,
 
 	// How long the toggle up/down takes in milliseconds
-	"ToggleDurationMs": 250
+	"ToggleDurationMs": 250,
+
+	// How far the terminal should come down, in percentage (eg. 50 = half way, 100 = full screen)
+	"VerticalScreenCoverage": 100
 
 	// HotKeys.Modifiers:
 	// Alt, Control, Shift, Windows

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -1,0 +1,86 @@
+﻿{
+	// The keys that can be used to toggle the terminal
+	"HotKeys": [
+		{
+			"Modifiers": "Control",
+			"Key": "OemTilde"
+		},
+		{
+			"Modifiers": "Control",
+			"Key": "Q"
+		}
+	],
+
+	// Whether to show notifications when the app starts and when the settings are reloaded
+	"Notifications": true,
+
+	// How long the toggle up/down takes in milliseconds
+	"ToggleDurationMs": 250
+
+	// HotKeys.Modifiers:
+	// Alt, Control, Shift, Windows
+	// HotKeys.Key:
+
+	// // Special keys
+	// Alt
+	// Back
+	// CapsLock
+	// Control
+	// Escape
+	// LControlKey
+	// LShiftKey
+	// LWin
+	// RControlKey
+	// RShiftKey
+	// RWin
+	// Shift
+	// Space
+	// Tab
+	// 
+	// // Middle part of the keyboard
+	// Delete
+	// End
+	// Home
+	// Insert
+	// PageDown
+	// PageUp
+	// PrintScreen
+	// 
+	// Down
+	// Left
+	// Right
+	// Up
+	// 
+	// // Number keys
+	// D0 - D9
+	// 
+	// // Letters
+	// A-Z
+	// 
+	// // Numpad
+	// NumPad0 - NumPad9
+	// Add
+	// Decimal
+	// Divide
+	// Multiply
+	// NumLock
+	// Separator
+	// Subtract
+	// 
+	// // Function keys
+	// F1 - F24
+	// 
+	// // Special characters
+	// OemBackslash
+	// OemCloseBrackets
+	// Oemcomma
+	// OemMinus
+	// OemOpenBrackets
+	// OemPeriod
+	// OemPipe
+	// Oemplus
+	// OemQuestion
+	// OemQuotes
+	// OemSemicolon
+	// Oemtilde
+}


### PR DESCRIPTION
Settings file can be in one of the following locations (in order, first found is used):
- C:\Users\<username>\windows-terminal-quake.json
- <windows-terminal-quake.exe directory>\windows-terminal-quake.json

The download contains a settings file with defaults.

These settings are available:

## Hotkeys
- One modifier (control. alt, etc.)
- Key (Q, OemTilde, etc.)
- Can be multiple, see settings file for examples and available keys & modifiers.

## Notifications
- Bottom-right notifications when the app is started and when settings are reloaded

## ToggleDurationMs
- How long the toggle animation takes, in milliseconds. 0 turns off the animation and makes it instant.

## VerticalScreenCoverage
- How far the terminal should come down, in percentage (eg. 50 = half way, 100 = full screen)
