### PR TITLE
Fix exiting wrapper

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,20 @@
 ﻿[*]
-indent_style = tab
+indent_style=tab
 
-dotnet_diagnostic.CA1031.severity = none # CA1031: Do not catch general exception types
-dotnet_diagnostic.CA1034.severity = none # CA1034: Nested types should not be visible
-dotnet_diagnostic.CA1054.severity = none # CA1054: Uri parameters should not be strings
-dotnet_diagnostic.CA1303.severity = none # CA1303: Do not pass literals as localized parameters
-dotnet_diagnostic.CA1305.severity = none # CA1305: Specify IFormatProvider
-dotnet_diagnostic.CA1308.severity = none # CA1308: Normalize strings to uppercase
-dotnet_diagnostic.CA1819.severity = none # CA1819: Properties should not return arrays
-dotnet_diagnostic.CA2007.severity = none # CA2007: Consider calling ConfigureAwait on the awaited task
-dotnet_diagnostic.CA2229.severity = none # CA2229: Implement serialization constructors
-dotnet_diagnostic.CS1591.severity = none # CS1591: Missing XML comment for publicly visible type or member
+dotnet_diagnostic.ca1031.severity=none # CA1031: Do not catch general exception types
+dotnet_diagnostic.ca1034.severity=none # CA1034: Nested types should not be visible
+dotnet_diagnostic.ca1054.severity=none # CA1054: Uri parameters should not be strings
+dotnet_diagnostic.ca1303.severity=none # CA1303: Do not pass literals as localized parameters
+dotnet_diagnostic.ca1305.severity=none # CA1305: Specify IFormatProvider
+dotnet_diagnostic.ca1308.severity=none # CA1308: Normalize strings to uppercase
+dotnet_diagnostic.ca1819.severity=none # CA1819: Properties should not return arrays
+dotnet_diagnostic.ca2007.severity=none # CA2007: Consider calling ConfigureAwait on the awaited task
+dotnet_diagnostic.ca2229.severity=none # CA2229: Implement serialization constructors
+dotnet_diagnostic.cs1591.severity=none # CS1591: Missing XML comment for publicly visible type or member
+
+# Microsoft .NET properties
+csharp_indent_braces=false
+csharp_new_line_before_open_brace=all
+
+# ReSharper properties
+resharper_csharp_case_block_braces=next_line

--- a/windows-terminal-quake/Program.cs
+++ b/windows-terminal-quake/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Windows.Forms;
@@ -13,6 +12,7 @@ namespace WindowsTerminalQuake
 	{
 		private static Toggler _toggler;
 		private static TrayIcon _trayIcon;
+		private static Process _process;
 
 		public static void Main(string[] args)
 		{
@@ -22,10 +22,10 @@ namespace WindowsTerminalQuake
 
 			try
 			{
-				Process process = Process.GetProcessesByName("WindowsTerminal").FirstOrDefault();
-				if (process == null)
+				_process = Process.GetProcessesByName("WindowsTerminal").FirstOrDefault();
+				if (_process == null)
 				{
-					process = new Process
+					_process = new Process
 					{
 						StartInfo = new ProcessStartInfo
 						{
@@ -33,28 +33,23 @@ namespace WindowsTerminalQuake
 							UseShellExecute = false,
 							RedirectStandardOutput = true,
 							WindowStyle = ProcessWindowStyle.Maximized,
-							CreateNoWindow = true,
 						}
 					};
-					process.Start();
-					process = Process.GetProcessesByName("WindowsTerminal").First();
-					process.WaitForInputIdle();
-					process.Refresh();
-					Log.Logger.Information("process was started from quake console (to be tested values)");
-					LogProcessInformation(process);
+					_process.Start();
+					EnsureThatProcessIsAccessible();
 				}
 
-				process.EnableRaisingEvents = true;
-				process.Exited += (sender, e) =>
+				_process.EnableRaisingEvents = true;
+				_process.Exited += (sender, e) =>
 				{
 					Close();
 				};
-				_toggler = new Toggler(process);
+				_toggler = new Toggler(_process);
 
 				// Transparency
 				Settings.Get(s =>
 				{
-					TransparentWindow.SetTransparent(process, s.Opacity);
+					TransparentWindow.SetTransparent(_process, s.Opacity);
 				});
 
 				var hks = string.Join(" or ", Settings.Instance.Hotkeys.Select(hk => $"{hk.Modifiers}+{hk.Key}"));
@@ -70,6 +65,29 @@ namespace WindowsTerminalQuake
 			}
 		}
 
+		private static void EnsureThatProcessIsAccessible()
+		{
+			if (_process == null || _process.HasExited)
+			{
+				throw new Exception("Can not ensure exited process is accessible");
+			}
+
+			try
+			{
+				// Note: Accessing mainWindowHandle already throws "Process has exited, so the requested information is not available."
+				if (_process.MainWindowHandle == IntPtr.Zero)
+				{
+					throw new Exception("Can not access newly started process.");
+				}
+			}
+			catch (Exception)
+			{
+				_process = Process.GetProcessesByName("WindowsTerminal").First();
+				// _process.WaitForInputIdle();
+				_process.Refresh();
+			}
+		}
+
 		private static void Close()
 		{
 			_toggler?.Dispose();
@@ -77,23 +95,6 @@ namespace WindowsTerminalQuake
 
 			_trayIcon?.Dispose();
 			_trayIcon = null;
-		}
-
-		private static void LogProcessInformation(Process process)
-		{
-			foreach (PropertyDescriptor descriptor in TypeDescriptor.GetProperties(process))
-			{
-				string name = descriptor.Name;
-				if (new[] {"ExitCode", "ExitTime", "BasePriority", "StandardInput", "StandardOutput", "StandardError"}.Any(x =>
-					x == name))
-				{
-					continue;
-				}
-
-				object value = descriptor.GetValue(process);
-
-				Log.Logger.Information("Process: {0}={1}", name, value);
-			}
 		}
 	}
 }


### PR DESCRIPTION
First iteration towards solving the problem described in #13

The problem seemed to be that the process that starts the Windows Terminal itself is terminating, after which the process with name `WindowsTerminal` becomes available.

This pull request makes the process is always started and correctly selected as well.

Fixes #13