### PR TITLE
Fix "the sequence contains no elements" error

### DIFF
--- a/windows-terminal-quake/Program.cs
+++ b/windows-terminal-quake/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Diagnostics;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 using WindowsTerminalQuake.Native;
 using WindowsTerminalQuake.UI;
@@ -65,6 +66,9 @@ namespace WindowsTerminalQuake
 					}
 				};
 				process.Start();
+
+				// Needed for the process to initialise and become accessible
+				Thread.Sleep(200);
 
 				try
 				{


### PR DESCRIPTION
This takes care of the error "the sequence contains no elements".

I tried reducing it to 25 or 50 milliseconds which still proved to be unstable. Hope this will fix the problem for everyone.

I have the feeling it has something to do with the targeted framework.