### PR TITLE
start wt.exe with UseShellExecute=false to enable loading of settings

### DIFF
--- a/windows-terminal-quake/Native/TerminalProcess.cs
+++ b/windows-terminal-quake/Native/TerminalProcess.cs
@@ -68,6 +68,7 @@ namespace WindowsTerminalQuake.Native
 					StartInfo = new ProcessStartInfo
 					{
 						FileName = newProcessName,
+						UseShellExecute = false,
 						WindowStyle = ProcessWindowStyle.Maximized
 					}
 				};


### PR DESCRIPTION
On my machine wt.exe fails to load settings.json when it is launched by windows-terminal-quake. It works for me if I set useShellExecute=false in ProcessStartInfo. Not sure if that's consistent though or if the error is common in the first place.