### PR TITLE
add scoop support

### DIFF
--- a/scoop/windows-terminal-quake.json
+++ b/scoop/windows-terminal-quake.json
@@ -1,0 +1,19 @@
+{
+  "version": "v0.11",
+  "description": "Companion program for the new Windows Terminal that enables Quake-style drop down",
+  "homepage": "https://github.com/flyingpie/windows-terminal-quake",
+  "bin": "windows-terminal-quake.exe",
+  "persist": "windows-terminal-quake.json",
+  "checkver": "github",
+  "architecture": {
+    "64bit": {
+      "url": "https://github.com/flyingpie/windows-terminal-quake/releases/download/v0.11/windows-terminal-quake-v0.11-2020-11-02_0001.zip",
+      "hash": "2d49e5d10519c48e0ec63b6f8328e11bc95c53b9f0948adee6862ed88213c726"
+    }
+  },
+  "suggest": {
+    "terminal": [
+      "main/windows-terminal"
+    ]
+  }
+}


### PR DESCRIPTION
scoop allows windows users to install programs from console, apt-like usage.

I use scoop to install my programs, windows terminal is included. Maybe this configuration can be tweaked better, tried to kickstart.

Also it would be a good idea to apply for main or extras bucket of scoop to appear on searches

Currently how to install with scoop is like below;
`scoop install https://github.com/Deliganli/windows-terminal-quake/blob/master/scoop/windows-terminal-quake.json`

If merged;
`scoop install https://github.com/flyingpie/windows-terminal-quake/blob/master/scoop/windows-terminal-quake.json`

If accepted into main or extras bucket;
`scoop install windows-terminal-quake`
