### PR TITLE
updated readme regarding scoop installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ There are a couple of options:
 - Download the latest release from the [releases page](https://github.com/flyingpie/windows-terminal-quake/releases).
 - Clone/download the source and run **build.ps1** (uses [Cakebuild](https://cakebuild.net/)).
 - Clone/download the source and build using Visual Studio.
+- Via [scoop](https://scoop.sh): `scoop install https://github.com/flyingpie/windows-terminal-quake/blob/master/scoop/windows-terminal-quake.json`
 
 ## Settings
 Since v0.4, the app supports a JSON settings file.


### PR DESCRIPTION
adds introduction on how to install with scoop. 

Instead of directly using the json file probably it is better to create a bucket since proposal for addition to `scoop-extras` has been rejected. However I am not sure how to do it at this point. Another time's problem.