### PR TITLE
Command Line Arguments

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 
 var configuration = Argument("configuration", "Release");
 var output = Argument("output", "artifacts");
-var version = Argument("version", "1.0.0");
+var version = Argument("version", "1.1.0");
 
 var sln = "windows-terminal-quake.sln";
 var bin = "./windows-terminal-quake/bin";

--- a/windows-terminal-quake/Native/TerminalProcess.cs
+++ b/windows-terminal-quake/Native/TerminalProcess.cs
@@ -40,7 +40,7 @@ namespace WindowsTerminalQuake.Native
 			_onExit.ForEach(a => a());
 		}
 
-		public static Process Get()
+		public static Process Get(string[] args)
 		{
 			return Retry.Execute(() =>
 			{
@@ -48,14 +48,14 @@ namespace WindowsTerminalQuake.Native
 
 				if (_process == null || _process.HasExited)
 				{
-					_process = GetOrCreate();
+					_process = GetOrCreate(args);
 				}
 
 				return _process;
 			});
 		}
 
-		private static Process GetOrCreate()
+		private static Process GetOrCreate(string[] args)
 		{
 			const string existingProcessName = "WindowsTerminal";
 			const string newProcessName = "wt.exe";
@@ -68,6 +68,7 @@ namespace WindowsTerminalQuake.Native
 					StartInfo = new ProcessStartInfo
 					{
 						FileName = newProcessName,
+						Arguments = string.Join(" ", args),
 						UseShellExecute = false,
 						WindowStyle = ProcessWindowStyle.Maximized
 					}

--- a/windows-terminal-quake/Program.cs
+++ b/windows-terminal-quake/Program.cs
@@ -39,12 +39,12 @@ namespace WindowsTerminalQuake
 			{
 				TerminalProcess.OnExit(() => Close());
 
-				_toggler = new Toggler();
+				_toggler = new Toggler(args);
 
 				// Transparency
 				Settings.Get(s =>
 				{
-					TransparentWindow.SetTransparent(TerminalProcess.Get(), s.Opacity);
+					TransparentWindow.SetTransparent(TerminalProcess.Get(args), s.Opacity);
 				});
 
 				var hks = string.Join(" or ", Settings.Instance.Hotkeys.Select(hk => $"{hk.Modifiers}+{hk.Key}"));

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -13,12 +13,15 @@ namespace WindowsTerminalQuake
 {
 	public class Toggler : IDisposable
 	{
-		private Process _process => TerminalProcess.Get();
+		private Process _process => TerminalProcess.Get(_args);
 
+		private string[] _args;
 		private readonly List<int> _registeredHotKeys = new List<int>();
 
-		public Toggler()
+		public Toggler(string[] args)
 		{
+			_args = args;
+
 			// Always on top
 			if (Settings.Instance.AlwaysOnTop) TopMostWindow.SetTopMost(_process);
 


### PR DESCRIPTION
Per request #52: Support for command line arguments that get passed to Windows Terminal.

Eg.
```shell
windows-terminal-quake.exe -d C:\PornTaxes2020 ; new-tab ; split-pane ; split-pane
```