### PR TITLE
Smooth toggle animations + support for different animation functions

### DIFF
--- a/windows-terminal-quake/Settings.cs
+++ b/windows-terminal-quake/Settings.cs
@@ -137,7 +137,7 @@ namespace WindowsTerminalQuake
 
 		public int ToggleDurationMs { get; set; } = 250;
 
-		public int ToggleAnimationFrameTimeMs { get; set; } = 25;
+		public string ToggleAnimationType { get; set; } = "linear";
 
 		public bool Logging { get; set; } = false;
 

--- a/windows-terminal-quake/Settings.cs
+++ b/windows-terminal-quake/Settings.cs
@@ -137,7 +137,7 @@ namespace WindowsTerminalQuake
 
 		public int ToggleDurationMs { get; set; } = 250;
 
-		public int ToggleAnimationFrameTimeMs { get; set; } = 8;
+		public int ToggleAnimationFrameTimeMs { get; set; } = 25;
 
 		public string ToggleAnimationType { get; set; } = "linear";
 

--- a/windows-terminal-quake/Settings.cs
+++ b/windows-terminal-quake/Settings.cs
@@ -137,6 +137,8 @@ namespace WindowsTerminalQuake
 
 		public int ToggleDurationMs { get; set; } = 250;
 
+		public int ToggleAnimationFrameTimeMs { get; set; } = 8;
+
 		public string ToggleAnimationType { get; set; } = "linear";
 
 		public bool Logging { get; set; } = false;

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -80,6 +80,9 @@ namespace WindowsTerminalQuake
 			var frameTimeMs = Settings.Instance.ToggleAnimationFrameTimeMs;
 
 			Log.Information(open?"Open":"Close");
+			if (open) {
+				FocusTracker.FocusGained(_process);
+			}
 			var screen = GetScreenWithCursor();
 			User32.ShowWindow(_process.MainWindowHandle, NCmdShow.RESTORE);
 			User32.SetForegroundWindow(_process.MainWindowHandle);

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
+using System.Threading;
 using System.Windows.Forms;
 using WindowsTerminalQuake.Native;
 using WindowsTerminalQuake.UI;
@@ -74,6 +75,7 @@ namespace WindowsTerminalQuake
 
 		public void Toggle(bool open, int durationMs) {
 			var animationFn = AnimationFunction(Settings.Instance.ToggleAnimationType);
+			var sleepMs = Settings.Instance.ToggleAnimationFrameTimeMs;
 
 			Log.Information(open?"Open":"Close");
 			var screen = GetScreenWithCursor();
@@ -87,6 +89,7 @@ namespace WindowsTerminalQuake
 			// Run the open/close animation
 			while (ts.TotalMilliseconds < durationMs)
 			{
+				Thread.Sleep(sleepMs);
 				ts = stopWatch.Elapsed;
 				var curMs = (double)ts.TotalMilliseconds;
 				var animationX = open ? (curMs / durationMs) : (1.0 - (curMs / durationMs));

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -22,9 +22,10 @@
 	// How long the toggle up/down takes in milliseconds.
 	"ToggleDurationMs": 250,
 
-	// How long each frame in the toggle animation takes in milliseconds.
-	// The lower this value, the smoother the animation, though values lower than 15 are not supported.
-	"ToggleAnimationFrameTimeMs": 25,
+	// Which animation type is used during toggle up/down.
+	// Examples: "linear", "easeInCubic", "easeOutCubic", "easeInQuart", "easeOutQuart", ... 
+	// (See also: https://easings.net/ ; note that not all of these functions are currently implemented.)
+	"ToggleAnimationType": "linear",
 
 	// How much room to leave between the top of the terminal and the top of the screen.
 	"VerticalOffset": 0,

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -22,9 +22,9 @@
 	// How long the toggle up/down takes in milliseconds.
 	"ToggleDurationMs": 250,
 
-	// How many milliseconds to wait between each frame in the animation.
-	// The lower this value, the smoother the animation. (can be 0)
-	"ToggleAnimationFrameTimeMs": 8,
+	// How long each frame in the toggle animation takes in milliseconds.
+	// The lower this value, the smoother the animation. (If set to 0, the frame rate limiter is removed.)
+	"ToggleAnimationFrameTimeMs": 15,
 
 	// Which animation type is used during toggle up/down.
 	// Examples: "linear", "easeInCubic", "easeOutCubic", "easeInQuart", "easeOutQuart", ... 

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -22,6 +22,10 @@
 	// How long the toggle up/down takes in milliseconds.
 	"ToggleDurationMs": 250,
 
+	// How many milliseconds to wait between each frame in the animation.
+	// The lower this value, the smoother the animation. (can be 0)
+	"ToggleAnimationFrameTimeMs": 8,
+
 	// Which animation type is used during toggle up/down.
 	// Examples: "linear", "easeInCubic", "easeOutCubic", "easeInQuart", "easeOutQuart", ... 
 	// (See also: https://easings.net/ ; note that not all of these functions are currently implemented.)

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -24,7 +24,7 @@
 
 	// How long each frame in the toggle animation takes in milliseconds.
 	// The lower this value, the smoother the animation. (If set to 0, the frame rate limiter is removed.)
-	"ToggleAnimationFrameTimeMs": 15,
+	"ToggleAnimationFrameTimeMs": 25,
 
 	// Which animation type is used during toggle up/down.
 	// Examples: "linear", "easeInCubic", "easeOutCubic", "easeInQuart", "easeOutQuart", ... 


### PR DESCRIPTION
Hey @flyingpie ,

I only just started playing with Windows Terminal, and it's perfect in combination with windows-terminal-quake! I really like it a lot! The only thing I couldn't get over was the open/close toggle animation being a little choppy, so I started digging through the code and saw that the `Task.Delay` statements in `Toggler.cs` are the culprit.

### Smooth toggle animations

To make the toggle animation really smooth, I ended up rewriting how the `Toggle` function works. Instead of a "move the window a little, then wait a little"-loop, it now just is a "move the window"-loop; no waiting/sleeping at all.

To know the correct position of the window at any time during the animation, I use a `Stopwatch` to measure many milliseconds have passed since the time the animation was started. (e.g. if `ToggleDurationMs` is set to 200 ms, and we know 100ms have passed, then the window has to be in the "half-open" position.)
Since the code now never sleeps, I also checked if this would cause CPU usage to rise during a toggle, but I can't really tell the difference .. CPU usage stays very low, no matter how often I try to mash Ctrl+` :p (I only tested it on my computer though; would be good to have a few more people try it out of course)

### Animation functions

The other part of this pull request is that I also added several kinds of "animation functions". A new "ToggleAnimationType" setting was added to the .json settings file for this. Currently the window moves at a constant speed during the open/close animation, but this PR adds several more options. (For example: first go fast, then slow down.. or the other way around .. You can get an idea of what the different options look like here: https://easings.net/ ) Most of the code for this is in the `Toggler.AnimationFunction` method.

---

That's it; let me know what you think :) .. and thanks again for making this awesome project!

Cheers,
 Tim