### PR TITLE
Added 'disable when in fullscreen mode' option

### DIFF
--- a/windows-terminal-quake/Native/User32.cs
+++ b/windows-terminal-quake/Native/User32.cs
@@ -13,6 +13,12 @@ namespace WindowsTerminalQuake.Native
 		public static extern IntPtr GetForegroundWindow();
 
 		[DllImport("user32.dll")]
+		public static extern IntPtr GetDesktopWindow();
+
+		[DllImport("user32.dll")]
+		public static extern IntPtr GetShellWindow();
+
+		[DllImport("user32.dll")]
 		public static extern IntPtr SetForegroundWindow(IntPtr hWnd);
 
 		[DllImport("user32.dll")]

--- a/windows-terminal-quake/Settings.cs
+++ b/windows-terminal-quake/Settings.cs
@@ -150,6 +150,8 @@ namespace WindowsTerminalQuake
 		public PreferMonitor PreferMonitor { get; set; } = PreferMonitor.WithCursor;
 
 		public int MonitorIndex { get; set; }
+
+		public bool DisableOnFullscreenWindow { get; set; } = true;
 	}
 
 	public class Hotkey

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -65,6 +65,11 @@ namespace WindowsTerminalQuake
 			// Toggle on hotkey(s)
 			HotKeyManager.HotKeyPressed += (s, a) =>
 			{
+				if (Settings.Instance.DisableOnFullscreenWindow && ActiveWindowIsInFullscreen())
+				{
+					return;
+				}
+
 				Toggle(!isOpen, Settings.Instance.ToggleDurationMs);
 				isOpen = !isOpen;
 			};
@@ -232,6 +237,23 @@ namespace WindowsTerminalQuake
 
 			// Restore window
 			User32.ShowWindow(process.MainWindowHandle, NCmdShow.MAXIMIZE);
+		}
+
+		private static bool ActiveWindowIsInFullscreen()
+		{
+			IntPtr fgWindow = User32.GetForegroundWindow();
+			User32.Rect appBounds = new User32.Rect();
+			User32.Rect screen = new User32.Rect();
+			User32.GetWindowRect(User32.GetDesktopWindow(), ref screen);
+
+			if (fgWindow != User32.GetDesktopWindow() && fgWindow != User32.GetShellWindow())
+			{
+				if(User32.GetWindowRect(fgWindow, ref appBounds))
+				{
+					return appBounds.Equals(screen);
+				}
+			}
+			return false;
 		}
 	}
 }

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -56,7 +56,10 @@
 
 	// If "PreferMonitor" is set to "AtIndex", this setting determines what monitor to choose.
 	// Zero based, eg. 0, 1, etc.
-	"MonitorIndex": 1
+	"MonitorIndex": 1,
+
+	// Disables toggling of the terminal window if active application is running in fullscreen mode on primary monitor
+	"DisableOnFullscreenWindow": true
 
 	// # HotKeys
 	// ## Modifiers


### PR DESCRIPTION
When turned on the new option prevents you from getting thrown onto the desktop when there is a window in fullscreen mode on the primary monitor (e.g. playing a video game).