### PR TITLE
Added shortcuts parameter to the scoop install json

### DIFF
--- a/scoop/windows-terminal-quake.json
+++ b/scoop/windows-terminal-quake.json
@@ -3,6 +3,12 @@
   "description": "Companion program for the new Windows Terminal that enables Quake-style drop down",
   "homepage": "https://github.com/flyingpie/windows-terminal-quake",
   "bin": "windows-terminal-quake.exe",
+  "shortcuts": [
+    [
+        "windows-terminal-quake.exe",
+        "Windows Terminal Quake"
+    ]
+],
   "persist": "windows-terminal-quake.json",
   "checkver": "github",
   "architecture": {


### PR DESCRIPTION
I added the shortcuts parameter which creates a native shortcut to .exe. 

It's just a small quality of life change so that you can select the exe right from the start menu with the file icon and so on to launch.

This is what the shortcut will look like. 
![image](https://user-images.githubusercontent.com/15869016/119177996-685c1980-ba6d-11eb-8b33-1d136599e50e.png)

You can still start quake mode from terminal by entering "windows-terminal-quake.exe" 
 