### PR TITLE
Proposal: Set default width to 80%, like the height.

### DIFF
--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -65,7 +65,7 @@
 	// How much horizontal space the terminal should use. When this is below 100, the terminal is centered.
 	// This can also be above 100, which can be useful to compensate for the window not always taking a 100% of the screen width,
 	// due to the terminal being bound to column widths (eg. try 100.5 or 101).
-	"HorizontalScreenCoverage": 100,
+	"HorizontalScreenCoverage": 80,
 
 	// How much room to leave between the top of the terminal and the top of the screen.
 	"VerticalOffset": 0,


### PR DESCRIPTION
Gives more of a console and portable feel if it doesn't cover the entire screen width.
It's somewhat subjective, but with the portable feel I mean that it's easier to understand that you can pop up the window on any of your screens.

I would argue that this is more user-friendly and therefor a better default.

Feel free to reject and close if you don't agree.