### PR TITLE
Build fix

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -2,7 +2,7 @@ trigger:
 - master
 
 pool:
-  vmImage: 'windows-2019'
+  vmImage: 'windows-2022'
 
 steps:
 - task: Cake@2

--- a/global.json
+++ b/global.json
@@ -1,5 +1,6 @@
 {
 	"sdk": {
-		"version": "6.0"
+		"version": "6.0.301",
+		"rollForward": "latestFeature"
 	}
 }

--- a/windows-terminal-quake/windows-terminal-quake.csproj
+++ b/windows-terminal-quake/windows-terminal-quake.csproj
@@ -4,7 +4,7 @@
 		<RootNamespace>WindowsTerminalQuake</RootNamespace>
 
 		<TargetFramework>net48</TargetFramework>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>11.0</LangVersion>
 		<Nullable>enable</Nullable>
 		<OutputType>WinExe</OutputType>
 


### PR DESCRIPTION
We needed to update the build agent to use VS2022, to allow using the new C# language versions.