### PR TITLE
ToggleMode - Initial

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -3,7 +3,7 @@
 
 var configuration = Argument("configuration", "Release");
 var output = Argument("output", "artifacts");
-var version = Argument("version", "1.4.0");
+var version = Argument("version", "1.5.0");
 
 var sln = "windows-terminal-quake.sln";
 var bin = $"./windows-terminal-quake/bin/{configuration}/net48";

--- a/schema/windows-terminal-quake.schema.1.json
+++ b/schema/windows-terminal-quake.schema.1.json
@@ -341,16 +341,6 @@
 			}
 		},
 
-		"KeepOriginalSize": {
-			"$id": "#/properties/KeepOriginalSize",
-
-			"title": "Keep Original Size",
-			"description": "TODO",
-
-			"type": "boolean",
-			"default": false
-		},
-
 		"LogLevel": {
 			"$id": "#/properties/LogLevel",
 
@@ -502,6 +492,7 @@
 			"description": "How the terminal actually gets toggled on- and off the screen.\n\nDefault \"Resize\" should work on any setup, but may cause character jumping due to the terminal changing shape.\n\n\"Move\" prevents this, but may not work with vertical monitor setups, pushing the terminal onto the northern monitor.",
 
 			"enum": [
+				"Initial",
 				"Move",
 				"Resize"
 			],

--- a/schema/windows-terminal-quake.schema.1.json
+++ b/schema/windows-terminal-quake.schema.1.json
@@ -341,6 +341,16 @@
 			}
 		},
 
+		"KeepOriginalSize": {
+			"$id": "#/properties/KeepOriginalSize",
+
+			"title": "Keep Original Size",
+			"description": "TODO",
+
+			"type": "boolean",
+			"default": false
+		},
+
 		"LogLevel": {
 			"$id": "#/properties/LogLevel",
 

--- a/windows-terminal-quake/Extensions/MathExtensions.cs
+++ b/windows-terminal-quake/Extensions/MathExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System.Drawing;
+using WindowsTerminalQuake.Native;
+
+namespace WindowsTerminalQuake.Extensions;
+
+public static class MathExtensions
+{
+	public static Rectangle ToRectangle(this Rect rect)
+		=> new(
+			x: rect.Left,
+			y: rect.Top,
+			width: rect.Right - rect.Left,
+			height: rect.Bottom - rect.Top);
+}

--- a/windows-terminal-quake/Extensions/ProcessExtensions.cs
+++ b/windows-terminal-quake/Extensions/ProcessExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Drawing;
+using WindowsTerminalQuake.Extensions;
 using WindowsTerminalQuake.Native;
 
 namespace System.Diagnostics;
@@ -12,16 +13,11 @@ public static class ProcessExtensions
 
 	public static Rectangle GetBounds(this Process process)
 	{
-		var bounds = new User32.Rect();
+		var bounds = new Rect();
 
 		User32.GetWindowRect(process.MainWindowHandle, ref bounds);
 
-		// TODO: Pull out conversions between Rectangle and Rect.
-		return new Rectangle(
-			x: bounds.Left,
-			y: bounds.Top,
-			width: bounds.Right - bounds.Left,
-			height: bounds.Bottom - bounds.Top);
+		return bounds.ToRectangle();
 	}
 
 	/// <summary>

--- a/windows-terminal-quake/Extensions/ProcessExtensions.cs
+++ b/windows-terminal-quake/Extensions/ProcessExtensions.cs
@@ -10,6 +10,20 @@ public static class ProcessExtensions
 		.WaitAndRetry(new[] { TimeSpan.FromMilliseconds(250), TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1) })
 	;
 
+	public static Rectangle GetBounds(this Process process)
+	{
+		var bounds = new User32.Rect();
+
+		User32.GetWindowRect(process.MainWindowHandle, ref bounds);
+
+		// TODO: Pull out conversions between Rectangle and Rect.
+		return new Rectangle(
+			x: bounds.Top,
+			y: bounds.Top,
+			width: bounds.Right - bounds.Left,
+			height: bounds.Bottom - bounds.Top);
+	}
+
 	/// <summary>
 	/// Sets the position and size of the process' main window.
 	/// </summary>

--- a/windows-terminal-quake/Extensions/ProcessExtensions.cs
+++ b/windows-terminal-quake/Extensions/ProcessExtensions.cs
@@ -18,7 +18,7 @@ public static class ProcessExtensions
 
 		// TODO: Pull out conversions between Rectangle and Rect.
 		return new Rectangle(
-			x: bounds.Top,
+			x: bounds.Left,
 			y: bounds.Top,
 			width: bounds.Right - bounds.Left,
 			height: bounds.Bottom - bounds.Top);

--- a/windows-terminal-quake/Native/Rect.cs
+++ b/windows-terminal-quake/Native/Rect.cs
@@ -1,0 +1,12 @@
+﻿namespace WindowsTerminalQuake.Native;
+
+public struct Rect
+{
+	public int Left { get; set; }
+
+	public int Top { get; set; }
+
+	public int Right { get; set; }
+
+	public int Bottom { get; set; }
+}

--- a/windows-terminal-quake/Native/User32.cs
+++ b/windows-terminal-quake/Native/User32.cs
@@ -4,6 +4,19 @@ namespace WindowsTerminalQuake.Native;
 
 public static class User32
 {
+	public const int GWL_EX_STYLE = -20;
+
+	public const int LWA_ALPHA = 0x2;
+
+	public const int WS_EX_APPWINDOW = 0x00040000;
+	public const int WS_EX_LAYERED = 0x80000;
+	public const int WS_EX_TOOLWINDOW = 0x00000080;
+
+	public static readonly IntPtr HWND_TOPMOST = new(-1);
+	public const uint SWP_NOSIZE = 0x0001;
+	public const uint SWP_NOMOVE = 0x0002;
+	public const uint TOPMOST_FLAGS = SWP_NOMOVE | SWP_NOSIZE;
+
 	[DllImport("user32.dll", SetLastError = true)]
 	public static extern IntPtr GetForegroundWindow();
 
@@ -43,28 +56,4 @@ public static class User32
 
 	[DllImport("user32.dll", SetLastError = true)]
 	public static extern bool UnregisterHotKey(IntPtr hWnd, int id);
-
-	public struct Rect
-	{
-		public int Left { get; set; }
-
-		public int Top { get; set; }
-
-		public int Right { get; set; }
-
-		public int Bottom { get; set; }
-	}
-
-	public const int GWL_EX_STYLE = -20;
-
-	public const int LWA_ALPHA = 0x2;
-
-	public const int WS_EX_APPWINDOW = 0x00040000;
-	public const int WS_EX_LAYERED = 0x80000;
-	public const int WS_EX_TOOLWINDOW = 0x00000080;
-
-	public static readonly IntPtr HWND_TOPMOST = new IntPtr(-1);
-	public const uint SWP_NOSIZE = 0x0001;
-	public const uint SWP_NOMOVE = 0x0002;
-	public const uint TOPMOST_FLAGS = SWP_NOMOVE | SWP_NOSIZE;
 }

--- a/windows-terminal-quake/Settings/SettingsDto.cs
+++ b/windows-terminal-quake/Settings/SettingsDto.cs
@@ -54,6 +54,11 @@ public class SettingsDto
 	public List<Hotkey>? Hotkeys { get; set; }
 
 	/// <summary>
+	/// TODO: Better name?
+	/// </summary>
+	public bool KeepOriginalSize { get; set; } = false;
+
+	/// <summary>
 	/// <para>Minimum level of events that are logged.</para>
 	/// <para>"Verbose", "Debug", "Information", "Warning", "Error" (default), "Fatal".</para>
 	/// </summary>

--- a/windows-terminal-quake/Settings/SettingsDto.cs
+++ b/windows-terminal-quake/Settings/SettingsDto.cs
@@ -54,11 +54,6 @@ public class SettingsDto
 	public List<Hotkey>? Hotkeys { get; set; }
 
 	/// <summary>
-	/// TODO: Better name?
-	/// </summary>
-	public bool KeepOriginalSize { get; set; } = false;
-
-	/// <summary>
 	/// <para>Minimum level of events that are logged.</para>
 	/// <para>"Verbose", "Debug", "Information", "Warning", "Error" (default), "Fatal".</para>
 	/// </summary>

--- a/windows-terminal-quake/Settings/ToggleMode.cs
+++ b/windows-terminal-quake/Settings/ToggleMode.cs
@@ -2,6 +2,13 @@
 
 public enum ToggleMode
 {
+	None = 0,
+
+	/// <summary>
+	/// Use the initial terminal position and size to toggle to- and from. Does not resize or reposition.
+	/// </summary>
+	Initial,
+
 	/// <summary>
 	/// "Move" keeps the size of the terminal constant, but moves the terminal off-screen to the top, which won't work great with vertically stacked monitors.
 	/// </summary>

--- a/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
@@ -17,6 +17,7 @@ public interface ITerminalBoundsProvider
 	/// The rectangle in which the terminal should appear/disappear (eg. target screen).
 	/// </param>
 	/// <param name="currentTerminalBounds">
+	/// The bounds of the terminal at the moment the function was called.
 	/// </param>
 	/// <param name="progress">
 	/// Value between 0.0 and 1.0 to indicate the desired position of the window;

--- a/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
@@ -21,5 +21,5 @@ public interface ITerminalBoundsProvider
 	/// <returns>
 	/// A <see cref="Rectangle"/> representing where the terminal should be positioned.
 	/// </returns>
-	Rectangle GetTerminalBounds(Rectangle screenBounds, double progress);
+	Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress);
 }

--- a/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
@@ -7,15 +7,16 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 /// </summary>
 public interface ITerminalBoundsProvider
 {
-	void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds);
-
-	void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds);
-
 	/// <summary>
 	/// Determine the window size & position during a toggle animation.
 	/// </summary>
+	/// <param name="isOpening">
+	/// Whether the calling toggler is currently opening (true) or closing (false).
+	/// </param>
 	/// <param name="screenBounds">
 	/// The rectangle in which the terminal should appear/disappear (eg. target screen).
+	/// </param>
+	/// <param name="currentTerminalBounds">
 	/// </param>
 	/// <param name="progress">
 	/// Value between 0.0 and 1.0 to indicate the desired position of the window;
@@ -25,5 +26,9 @@ public interface ITerminalBoundsProvider
 	/// <returns>
 	/// A <see cref="Rectangle"/> representing where the terminal should be positioned.
 	/// </returns>
-	Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress);
+	Rectangle GetTerminalBounds(
+		bool isOpening,
+		Rectangle screenBounds,
+		Rectangle currentTerminalBounds,
+		double progress);
 }

--- a/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ITerminalBoundsProvider.cs
@@ -7,6 +7,10 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 /// </summary>
 public interface ITerminalBoundsProvider
 {
+	void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds);
+
+	void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds);
+
 	/// <summary>
 	/// Determine the window size & position during a toggle animation.
 	/// </summary>

--- a/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
@@ -14,24 +14,6 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 		_initialBounds = initialBounds;
 	}
 
-	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
-	{
-		//OnToggle(open, currentTerminalBounds);
-	}
-
-	public void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
-	{
-		//OnToggle(open, currentTerminalBounds);
-	}
-
-	public void OnToggle(bool open, Rectangle currentTerminalBounds)
-	{
-		if (!open && currentTerminalBounds.Width > 100 && currentTerminalBounds.Height > 100)
-		{
-			_initialBounds = currentTerminalBounds;
-		}
-	}
-
 	/// <inheritdoc/>
 	public Rectangle GetTerminalBounds(
 		bool isOpening,

--- a/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
@@ -6,9 +6,9 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 {
 	private Rectangle _initialBounds;
 
-	public InitialTerminalBoundsProvider(Process wtProcess)
+	public InitialTerminalBoundsProvider(Rectangle initialBounds)
 	{
-		_initialBounds = wtProcess?.GetBounds() ?? throw new ArgumentNullException(nameof(wtProcess));
+		_initialBounds = initialBounds;
 	}
 
 	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
@@ -23,10 +23,10 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 
 	public void OnToggle(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
 	{
+		// TODO: Handle manual reposition and resize.
+
 		if (!open && currentTerminalBounds.Width > 100 && currentTerminalBounds.Height > 100)
 		{
-			Log.Debug($"OnToggle(open: {open}, screenBounds: {screenBounds}, currentTerminalBounds: {currentTerminalBounds})");
-
 			_initialBounds = currentTerminalBounds;
 		}
 	}
@@ -40,7 +40,7 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 			_initialBounds.X,
 
 			// Y, top of the screen + offset
-			screenBounds.Y + -screenBounds.Height + (int)Math.Round(screenBounds.Height * progress) + _initialBounds.Y,
+			-currentTerminalBounds.Height + (int)Math.Round(currentTerminalBounds.Height * progress) + _initialBounds.Y,
 
 			// Horizontal Width
 			_initialBounds.Width,

--- a/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
@@ -2,6 +2,9 @@
 
 namespace WindowsTerminalQuake.TerminalBoundsProviders;
 
+/// <summary>
+/// Moves the terminal from- and to where the user put it, maintaining both the original position and size.
+/// </summary>
 public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 {
 	private Rectangle _initialBounds;
@@ -13,15 +16,15 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 
 	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
 	{
-		OnToggle(open, screenBounds, currentTerminalBounds);
+		//OnToggle(open, currentTerminalBounds);
 	}
 
 	public void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
 	{
-		OnToggle(open, screenBounds, currentTerminalBounds);
+		//OnToggle(open, currentTerminalBounds);
 	}
 
-	public void OnToggle(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	public void OnToggle(bool open, Rectangle currentTerminalBounds)
 	{
 		if (!open && currentTerminalBounds.Width > 100 && currentTerminalBounds.Height > 100)
 		{
@@ -30,24 +33,38 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 	}
 
 	/// <inheritdoc/>
-	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
+	public Rectangle GetTerminalBounds(
+		bool isOpening,
+		Rectangle screenBounds,
+		Rectangle currentTerminalBounds,
+		double progress)
 	{
+		if (!isOpening && progress >= 1)
+		{
+			_initialBounds = currentTerminalBounds;
+		}
+
 		var res = new Rectangle
 		(
-			// X, based on the HorizontalAlign and HorizontalScreenCoverage settings
+			// Maintain initial X
 			_initialBounds.X,
 
-			// Y, top of the screen + offset
+			// Move to initial Y
 			-currentTerminalBounds.Height + (int)Math.Round(currentTerminalBounds.Height * progress) + _initialBounds.Y,
 
-			// Horizontal Width
+			// Initial width
 			_initialBounds.Width,
 
-			// Vertical Height
+			// Initial height
 			_initialBounds.Height
 		);
 
-		Log.Debug("Target screen bounds: {ScreenBounds}. Terminal bounds: {TerminalBounds}", screenBounds, res);
+		Log.Debug("Progress: {Progress} Target screen bounds: {ScreenBounds}. Terminal bounds: {TerminalBounds}", progress, screenBounds, res);
+
+		if (isOpening && progress >= 1)
+		{
+			_initialBounds = res;
+		}
 
 		return res;
 	}

--- a/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
@@ -23,8 +23,6 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 
 	public void OnToggle(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
 	{
-		// TODO: Handle manual reposition and resize.
-
 		if (!open && currentTerminalBounds.Width > 100 && currentTerminalBounds.Height > 100)
 		{
 			_initialBounds = currentTerminalBounds;
@@ -49,7 +47,7 @@ public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
 			_initialBounds.Height
 		);
 
-		Log.Debug($"Target screen bounds: {screenBounds}. Terminal bounds: {res}");
+		Log.Debug("Target screen bounds: {ScreenBounds}. Terminal bounds: {TerminalBounds}", screenBounds, res);
 
 		return res;
 	}

--- a/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/InitialTerminalBoundsProvider.cs
@@ -1,0 +1,56 @@
+﻿using System.Drawing;
+
+namespace WindowsTerminalQuake.TerminalBoundsProviders;
+
+public class InitialTerminalBoundsProvider : ITerminalBoundsProvider
+{
+	private Rectangle _initialBounds;
+
+	public InitialTerminalBoundsProvider(Process wtProcess)
+	{
+		_initialBounds = wtProcess?.GetBounds() ?? throw new ArgumentNullException(nameof(wtProcess));
+	}
+
+	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	{
+		OnToggle(open, screenBounds, currentTerminalBounds);
+	}
+
+	public void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	{
+		OnToggle(open, screenBounds, currentTerminalBounds);
+	}
+
+	public void OnToggle(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	{
+		if (!open && currentTerminalBounds.Width > 100 && currentTerminalBounds.Height > 100)
+		{
+			Log.Debug($"OnToggle(open: {open}, screenBounds: {screenBounds}, currentTerminalBounds: {currentTerminalBounds})");
+
+			_initialBounds = currentTerminalBounds;
+		}
+	}
+
+	/// <inheritdoc/>
+	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
+	{
+		var res = new Rectangle
+		(
+			// X, based on the HorizontalAlign and HorizontalScreenCoverage settings
+			_initialBounds.X,
+
+			// Y, top of the screen + offset
+			screenBounds.Y + -screenBounds.Height + (int)Math.Round(screenBounds.Height * progress) + _initialBounds.Y,
+
+			// Horizontal Width
+			_initialBounds.Width,
+
+			// Vertical Height
+			_initialBounds.Height
+		);
+
+		Log.Debug($"Target screen bounds: {screenBounds}. Terminal bounds: {res}");
+
+		return res;
+	}
+}

--- a/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
@@ -5,13 +5,18 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 public class MovingTerminalBoundsProvider : ITerminalBoundsProvider
 {
 	/// <inheritdoc/>
-	public Rectangle GetTerminalBounds(Rectangle screenBounds, double progress)
+	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
 	{
 		var settings = QSettings.Instance ?? throw new InvalidOperationException($"Settings.Instance was null");
 
 		// Calculate terminal size
-		var termWidth = (int)(screenBounds.Width * settings.HorizontalScreenCoverageIndex);
-		var termHeight = (int)(screenBounds.Height * settings.VerticalScreenCoverageIndex);
+		var termWidth = settings.KeepOriginalSize
+			? currentTerminalBounds.Width
+			: (int)(screenBounds.Width * settings.HorizontalScreenCoverageIndex);
+
+		var termHeight = settings.KeepOriginalSize
+			? currentTerminalBounds.Height
+			: (int)(screenBounds.Height * settings.VerticalScreenCoverageIndex);
 
 		// Calculate horizontal position, based on the terminal alignment and the alignment
 		var x = settings.HorizontalAlign switch

--- a/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
@@ -4,6 +4,14 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 
 public class MovingTerminalBoundsProvider : ITerminalBoundsProvider
 {
+	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	{
+	}
+
+	public void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	{
+	}
+
 	/// <inheritdoc/>
 	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
 	{

--- a/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
@@ -4,16 +4,12 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 
 public class MovingTerminalBoundsProvider : ITerminalBoundsProvider
 {
-	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
-	{
-	}
-
-	public void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
-	{
-	}
-
 	/// <inheritdoc/>
-	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
+	public Rectangle GetTerminalBounds(
+		bool isOpening,
+		Rectangle screenBounds,
+		Rectangle currentTerminalBounds,
+		double progress)
 	{
 		var settings = QSettings.Instance ?? throw new InvalidOperationException($"Settings.Instance was null");
 

--- a/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/MovingTerminalBoundsProvider.cs
@@ -18,13 +18,8 @@ public class MovingTerminalBoundsProvider : ITerminalBoundsProvider
 		var settings = QSettings.Instance ?? throw new InvalidOperationException($"Settings.Instance was null");
 
 		// Calculate terminal size
-		var termWidth = settings.KeepOriginalSize
-			? currentTerminalBounds.Width
-			: (int)(screenBounds.Width * settings.HorizontalScreenCoverageIndex);
-
-		var termHeight = settings.KeepOriginalSize
-			? currentTerminalBounds.Height
-			: (int)(screenBounds.Height * settings.VerticalScreenCoverageIndex);
+		var termWidth = (int)(screenBounds.Width * settings.HorizontalScreenCoverageIndex);
+		var termHeight = (int)(screenBounds.Height * settings.VerticalScreenCoverageIndex);
 
 		// Calculate horizontal position, based on the terminal alignment and the alignment
 		var x = settings.HorizontalAlign switch

--- a/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
@@ -4,16 +4,12 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 
 public class ResizingTerminalBoundsProvider : ITerminalBoundsProvider
 {
-	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
-	{
-	}
-
-	public void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
-	{
-	}
-
 	/// <inheritdoc/>
-	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
+	public Rectangle GetTerminalBounds(
+		bool isOpening,
+		Rectangle screenBounds,
+		Rectangle currentTerminalBounds,
+		double progress)
 	{
 		var settings = QSettings.Instance ?? throw new InvalidOperationException($"Settings.Instance was null");
 

--- a/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
@@ -18,13 +18,8 @@ public class ResizingTerminalBoundsProvider : ITerminalBoundsProvider
 		var settings = QSettings.Instance ?? throw new InvalidOperationException($"Settings.Instance was null");
 
 		// Calculate terminal size
-		var termWidth = settings.KeepOriginalSize
-			? currentTerminalBounds.Width
-			: (int)(screenBounds.Width * settings.HorizontalScreenCoverageIndex);
-
-		var termHeight = settings.KeepOriginalSize
-			? currentTerminalBounds.Height
-			: (int)(screenBounds.Height * settings.VerticalScreenCoverageIndex);
+		var termWidth = screenBounds.Width * settings.HorizontalScreenCoverageIndex;
+		var termHeight = screenBounds.Height * settings.VerticalScreenCoverageIndex;
 
 		// Calculate horizontal position, based on the terminal alignment and the alignment
 		var x = settings.HorizontalAlign switch

--- a/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
@@ -4,6 +4,14 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 
 public class ResizingTerminalBoundsProvider : ITerminalBoundsProvider
 {
+	public void OnToggleStart(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	{
+	}
+
+	public void OnToggleEnd(bool open, Rectangle screenBounds, Rectangle currentTerminalBounds)
+	{
+	}
+
 	/// <inheritdoc/>
 	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
 	{

--- a/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
+++ b/windows-terminal-quake/TerminalBoundsProviders/ResizingTerminalBoundsProvider.cs
@@ -5,13 +5,18 @@ namespace WindowsTerminalQuake.TerminalBoundsProviders;
 public class ResizingTerminalBoundsProvider : ITerminalBoundsProvider
 {
 	/// <inheritdoc/>
-	public Rectangle GetTerminalBounds(Rectangle screenBounds, double progress)
+	public Rectangle GetTerminalBounds(Rectangle screenBounds, Rectangle currentTerminalBounds, double progress)
 	{
 		var settings = QSettings.Instance ?? throw new InvalidOperationException($"Settings.Instance was null");
 
 		// Calculate terminal size
-		var termWidth = screenBounds.Width * settings.HorizontalScreenCoverageIndex;
-		var termHeight = screenBounds.Height * settings.VerticalScreenCoverageIndex;
+		var termWidth = settings.KeepOriginalSize
+			? currentTerminalBounds.Width
+			: (int)(screenBounds.Width * settings.HorizontalScreenCoverageIndex);
+
+		var termHeight = settings.KeepOriginalSize
+			? currentTerminalBounds.Height
+			: (int)(screenBounds.Height * settings.VerticalScreenCoverageIndex);
 
 		// Calculate horizontal position, based on the terminal alignment and the alignment
 		var x = settings.HorizontalAlign switch

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -126,7 +126,7 @@ public class Toggler : IDisposable
 				: (1.0 - (deltaMs / durationMs))
 			;
 
-			var intermediateBounds = _termBoundsProvider.GetTerminalBounds(screen, animationFn(linearProgress));
+			var intermediateBounds = _termBoundsProvider.GetTerminalBounds(screen, Process.GetBounds(), animationFn(linearProgress));
 
 			Process.MoveWindow(bounds: intermediateBounds);
 
@@ -138,7 +138,7 @@ public class Toggler : IDisposable
 		stopwatch.Stop();
 
 		// To ensure sure we end up in exactly the correct final position
-		var finalBounds = _termBoundsProvider.GetTerminalBounds(screen, open ? 1.0 : 0.0);
+		var finalBounds = _termBoundsProvider.GetTerminalBounds(screen, Process.GetBounds(), open ? 1.0 : 0.0);
 		Process.MoveWindow(bounds: finalBounds);
 
 		if (open)

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -184,8 +184,8 @@ public class Toggler : IDisposable
 	private static bool ActiveWindowIsInFullscreen()
 	{
 		IntPtr fgWindow = User32.GetForegroundWindow();
-		User32.Rect appBounds = new User32.Rect();
-		User32.Rect screen = new User32.Rect();
+		var appBounds = new Rect();
+		var screen = new Rect();
 		User32.GetWindowRect(User32.GetDesktopWindow(), ref screen);
 
 		if (fgWindow != User32.GetDesktopWindow() && fgWindow != User32.GetShellWindow())

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -106,8 +106,6 @@ public class Toggler : IDisposable
 
 		var screen = _scrBoundsProvider.GetTargetScreenBounds();
 
-		_termBoundsProvider.OnToggleStart(open, screen, Process.GetBounds());
-
 		// Used to accurately measure how far we are in the animation
 		var stopwatch = new Stopwatch();
 		stopwatch.Start();
@@ -129,7 +127,7 @@ public class Toggler : IDisposable
 				: (1.0 - (deltaMs / durationMs))
 			;
 
-			var intermediateBounds = _termBoundsProvider.GetTerminalBounds(screen, Process.GetBounds(), animationFn(linearProgress));
+			var intermediateBounds = _termBoundsProvider.GetTerminalBounds(open, screen, Process.GetBounds(), animationFn(linearProgress));
 
 			Process.MoveWindow(bounds: intermediateBounds);
 
@@ -141,7 +139,7 @@ public class Toggler : IDisposable
 		stopwatch.Stop();
 
 		// To ensure sure we end up in exactly the correct final position
-		var finalBounds = _termBoundsProvider.GetTerminalBounds(screen, Process.GetBounds(), open ? 1.0 : 0.0);
+		var finalBounds = _termBoundsProvider.GetTerminalBounds(open, screen, Process.GetBounds(), open ? 1.0 : 0.0);
 		Process.MoveWindow(bounds: finalBounds);
 
 		if (open)
@@ -161,8 +159,6 @@ public class Toggler : IDisposable
 			if (QSettings.Instance.TaskbarIconVisibility == TaskBarIconVisibility.AlwaysHidden || QSettings.Instance.TaskbarIconVisibility == TaskBarIconVisibility.WhenTerminalVisible)
 				Process.SetWindowState(WindowShowStyle.Hide);
 		}
-
-		_termBoundsProvider.OnToggleEnd(open, screen, Process.GetBounds());
 	}
 
 	public void Dispose()

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -52,6 +52,7 @@ public class Toggler : IDisposable
 		{
 			_termBoundsProvider = s.ToggleMode switch
 			{
+				ToggleMode.Initial => new InitialTerminalBoundsProvider(Process),
 				ToggleMode.Move => new MovingTerminalBoundsProvider(),
 				_ => new ResizingTerminalBoundsProvider()
 			};
@@ -104,6 +105,8 @@ public class Toggler : IDisposable
 		Process.BringToForeground();
 
 		var screen = _scrBoundsProvider.GetTargetScreenBounds();
+
+		_termBoundsProvider.OnToggleStart(open, screen, Process.GetBounds());
 
 		// Used to accurately measure how far we are in the animation
 		var stopwatch = new Stopwatch();
@@ -158,6 +161,8 @@ public class Toggler : IDisposable
 			if (QSettings.Instance.TaskbarIconVisibility == TaskBarIconVisibility.AlwaysHidden || QSettings.Instance.TaskbarIconVisibility == TaskBarIconVisibility.WhenTerminalVisible)
 				Process.SetWindowState(WindowShowStyle.Hide);
 		}
+
+		_termBoundsProvider.OnToggleEnd(open, screen, Process.GetBounds());
 	}
 
 	public void Dispose()

--- a/windows-terminal-quake/Toggler.cs
+++ b/windows-terminal-quake/Toggler.cs
@@ -52,7 +52,7 @@ public class Toggler : IDisposable
 		{
 			_termBoundsProvider = s.ToggleMode switch
 			{
-				ToggleMode.Initial => new InitialTerminalBoundsProvider(Process),
+				ToggleMode.Initial => new InitialTerminalBoundsProvider(Process.GetBounds()),
 				ToggleMode.Move => new MovingTerminalBoundsProvider(),
 				_ => new ResizingTerminalBoundsProvider()
 			};

--- a/windows-terminal-quake/windows-terminal-quake.json
+++ b/windows-terminal-quake/windows-terminal-quake.json
@@ -61,6 +61,10 @@
 	/// Size & Align
 	////////////////////////////////////////////////////////////////////////////////////
 
+	// Whether to maintain the current size of the terminal (as it was when first opened, and possible resizes done by the user).
+	// If "false", the terminal will be sized based on the settings below.
+	"KeepOriginalSize": false,
+
 	// When "HorizontalScreenCoverage" is below 100, this setting determines where the terminal is place horizontally.
 	// "Center", "Left" or "Right".
 	"HorizontalAlign": "Center",


### PR DESCRIPTION
Maintain the original size of the terminal, without resizing to eg. horizontal coverage.

The mode looks for the last known position & size of the terminal (when visible), and keeps that as the target. If the terminal window is manually moved or resized, those changes will become the new target for moving to.

Ignores the "*coverage" and preferred monitor settings.

As suggested by [mkanet](https://github.com/mkanet) in #114 