### PR TITLE
feat: per-screen app toggling for multi-monitor setups

### DIFF
--- a/src/10-Core/Wtq.UnitTest/Services/WtqAppRepoPerScreenTest.cs
+++ b/src/10-Core/Wtq.UnitTest/Services/WtqAppRepoPerScreenTest.cs
@@ -1,12 +1,14 @@
+using System.Collections.Generic;
+using System.Linq;
 using Wtq.Configuration;
+using Wtq.Services;
 
 namespace Wtq.Core.UnitTest.Services;
 
 /// <summary>
-/// Tests for the per-screen app toggling feature.
-/// The core logic relies on <see cref="Rectangle.IntersectsWith(Rectangle)"/> to determine
-/// whether a WTQ app on one screen would conflict with a toggle on another screen.
-/// These tests validate the screen-intersection assumptions.
+/// Tests for per-screen app toggling behavior.
+/// Validates rectangle intersection assumptions that the <see cref="IWtqAppRepo.GetOpenOnScreen"/>
+/// method relies on, as well as the <see cref="FeatureFlags.PerScreenApps"/> default value.
 /// </summary>
 [TestClass]
 public class WtqAppRepoPerScreenTest
@@ -78,5 +80,67 @@ public class WtqAppRepoPerScreenTest
 		// Side monitors don't intersect each other.
 		Assert.IsFalse(leftScreen.IntersectsWith(rightScreen),
 			"Left and right screens should not intersect");
+	}
+
+	[TestMethod]
+	public void GetOpenOnScreen_ReturnsEmpty_WhenNoAppsMatch()
+	{
+		// Verify that filtering open apps by screen returns an empty collection
+		// when no apps have a CurrentScreenRect matching the query rectangle.
+		var apps = new List<WtqApp>();
+
+		var result = apps.Where(a =>
+			a is { IsAttached: true, IsOpen: true } &&
+			a.CurrentScreenRect.HasValue &&
+			a.CurrentScreenRect.Value.IntersectsWith(new Rectangle(5000, 5000, 1920, 1080)));
+
+		Assert.IsNotNull(result, "Filtered result should never be null");
+		Assert.AreEqual(0, result.Count(), "No apps should match a far-off screen rect");
+	}
+
+	[TestMethod]
+	public void GetOpenOnScreen_ReturnsMultipleApps_OnSameScreen()
+	{
+		// Simulate two open apps on the same screen rect.
+		// The method should return all of them, not just the first.
+		var screen = new Rectangle(0, 0, 1920, 1080);
+
+		// Create a minimal list that simulates two apps sharing a screen.
+		// Since WtqApp is hard to construct in tests, we verify the filter
+		// predicate logic directly.
+		var testData = new[]
+		{
+			new { IsAttached = true, IsOpen = true, CurrentScreenRect = (Rectangle?)screen },
+			new { IsAttached = true, IsOpen = true, CurrentScreenRect = (Rectangle?)screen },
+			new { IsAttached = true, IsOpen = false, CurrentScreenRect = (Rectangle?)screen }, // closed app
+		};
+
+		var matching = testData.Where(a =>
+			a.IsAttached && a.IsOpen &&
+			a.CurrentScreenRect.HasValue &&
+			a.CurrentScreenRect.Value.IntersectsWith(screen)).ToList();
+
+		Assert.AreEqual(2, matching.Count, "Should return exactly 2 open apps on the same screen");
+	}
+
+	[TestMethod]
+	public void GetOpenOnScreen_ExcludesApps_OnDifferentScreen()
+	{
+		var primaryScreen = new Rectangle(0, 0, 1920, 1080);
+		var secondaryScreen = new Rectangle(1920, 0, 1920, 1080);
+
+		var testData = new[]
+		{
+			new { IsAttached = true, IsOpen = true, CurrentScreenRect = (Rectangle?)primaryScreen },
+			new { IsAttached = true, IsOpen = true, CurrentScreenRect = (Rectangle?)secondaryScreen },
+		};
+
+		// Query for primary screen should only return the app on the primary screen.
+		var onPrimary = testData.Where(a =>
+			a.IsAttached && a.IsOpen &&
+			a.CurrentScreenRect.HasValue &&
+			a.CurrentScreenRect.Value.IntersectsWith(primaryScreen)).ToList();
+
+		Assert.AreEqual(1, onPrimary.Count, "Only one app should match the primary screen");
 	}
 }

--- a/src/10-Core/Wtq.UnitTest/Services/WtqAppRepoPerScreenTest.cs
+++ b/src/10-Core/Wtq.UnitTest/Services/WtqAppRepoPerScreenTest.cs
@@ -1,0 +1,82 @@
+using Wtq.Configuration;
+
+namespace Wtq.Core.UnitTest.Services;
+
+/// <summary>
+/// Tests for the per-screen app toggling feature.
+/// The core logic relies on <see cref="Rectangle.IntersectsWith(Rectangle)"/> to determine
+/// whether a WTQ app on one screen would conflict with a toggle on another screen.
+/// These tests validate the screen-intersection assumptions.
+/// </summary>
+[TestClass]
+public class WtqAppRepoPerScreenTest
+{
+	[TestMethod]
+	public void PerScreenApps_DefaultValue_IsTrue()
+	{
+		var flags = new FeatureFlags();
+		Assert.IsTrue(flags.PerScreenApps);
+	}
+
+	[TestMethod]
+	public void AdjacentHorizontalMonitorRects_DoNotIntersect()
+	{
+		// Common dual-monitor setup: primary at (0,0), secondary immediately to the right.
+		var primaryScreen = new Rectangle(0, 0, 1920, 1080);
+		var secondaryScreen = new Rectangle(1920, 0, 1920, 1080);
+
+		Assert.IsFalse(primaryScreen.IntersectsWith(secondaryScreen),
+			"Adjacent horizontal monitors should not intersect, so apps on each screen are independent");
+	}
+
+	[TestMethod]
+	public void OverlappingMonitorRects_DoIntersect()
+	{
+		// Some monitor setups have slight overlap (e.g., 10px overlap).
+		var screenA = new Rectangle(0, 0, 1930, 1080);
+		var screenB = new Rectangle(1920, 0, 1920, 1080);
+
+		Assert.IsTrue(screenA.IntersectsWith(screenB),
+			"Overlapping monitors should intersect, so apps would conflict");
+	}
+
+	[TestMethod]
+	public void IdenticalScreenRects_Intersect()
+	{
+		// An app on a screen should match a query for that same screen.
+		var screen = new Rectangle(0, 0, 1920, 1080);
+
+		Assert.IsTrue(screen.IntersectsWith(screen),
+			"A screen should intersect with itself");
+	}
+
+	[TestMethod]
+	public void VerticalStackedMonitorRects_DoNotIntersect()
+	{
+		// Vertical stacked monitors (one above the other).
+		var topScreen = new Rectangle(0, -1080, 1920, 1080);
+		var bottomScreen = new Rectangle(0, 0, 1920, 1080);
+
+		Assert.IsFalse(topScreen.IntersectsWith(bottomScreen),
+			"Vertically stacked adjacent monitors should not intersect");
+	}
+
+	[TestMethod]
+	public void TripleHorizontalSetup_NoCrossScreenIntersection()
+	{
+		// Left monitor | Primary | Right monitor
+		var leftScreen = new Rectangle(-1920, 0, 1920, 1080);
+		var primaryScreen = new Rectangle(0, 0, 1920, 1080);
+		var rightScreen = new Rectangle(1920, 0, 1920, 1080);
+
+		// Primary does not intersect with either side monitor.
+		Assert.IsFalse(primaryScreen.IntersectsWith(leftScreen),
+			"Primary screen should not intersect with left screen");
+		Assert.IsFalse(primaryScreen.IntersectsWith(rightScreen),
+			"Primary screen should not intersect with right screen");
+
+		// Side monitors don't intersect each other.
+		Assert.IsFalse(leftScreen.IntersectsWith(rightScreen),
+			"Left and right screens should not intersect");
+	}
+}

--- a/src/10-Core/Wtq/Configuration/FeatureFlags.cs
+++ b/src/10-Core/Wtq/Configuration/FeatureFlags.cs
@@ -16,4 +16,14 @@ public class FeatureFlags
 	/// While implementing this, some subtle issues were encountered. Although all the known ones have been fixed, it's enough of a change that we're feature-flagging it for a while.
 	/// </summary>
 	public bool SharpHook { get; set; }
+
+	/// <summary>
+	/// When enabled, allows one WTQ app per screen instead of one globally.<br/>
+	/// Toggling an app on a screen only closes other WTQ apps on that same screen, allowing apps on
+	/// different monitors to remain open simultaneously.<br/>
+	/// <br/>
+	/// When disabled, restores the legacy behavior where toggling any app closes the previously-open app
+	/// regardless of which screen it was on.
+	/// </summary>
+	public bool PerScreenApps { get; set; } = true;
 }

--- a/src/10-Core/Wtq/Configuration/FeatureFlags.cs
+++ b/src/10-Core/Wtq/Configuration/FeatureFlags.cs
@@ -21,11 +21,11 @@ public class FeatureFlags
 
 	/// <summary>
 	/// When enabled, allows one WTQ app per screen instead of one globally.<br/>
-	/// Toggling an app on a screen only closes other WTQ apps on that same screen, allowing apps on
-	/// different monitors to remain open simultaneously.<br/>
+	/// Toggling an app on a screen only closes other WTQ apps on that same screen,
+	/// allowing apps on different monitors to remain open simultaneously.<br/>
 	/// <br/>
-	/// When disabled, restores the legacy behavior where toggling any app closes the previously-open app
-	/// regardless of which screen it was on.
+	/// When disabled, restores the legacy behavior where toggling any app closes the
+	/// previously-open app regardless of which screen it was on.
 	/// </summary>
 	[DefaultValue(true)]
 	[Display(Name = "Per-screen apps", Prompt = "Allow one app per monitor")]

--- a/src/10-Core/Wtq/Configuration/FeatureFlags.cs
+++ b/src/10-Core/Wtq/Configuration/FeatureFlags.cs
@@ -15,6 +15,8 @@ public class FeatureFlags
 	/// <br/>
 	/// While implementing this, some subtle issues were encountered. Although all the known ones have been fixed, it's enough of a change that we're feature-flagging it for a while.
 	/// </summary>
+	[DefaultValue(false)]
+	[Display(Name = "SharpHook hotkeys", Prompt = "Use SharpHook for hotkey registration")]
 	public bool SharpHook { get; set; }
 
 	/// <summary>
@@ -25,5 +27,7 @@ public class FeatureFlags
 	/// When disabled, restores the legacy behavior where toggling any app closes the previously-open app
 	/// regardless of which screen it was on.
 	/// </summary>
+	[DefaultValue(true)]
+	[Display(Name = "Per-screen apps", Prompt = "Allow one app per monitor")]
 	public bool PerScreenApps { get; set; } = true;
 }

--- a/src/10-Core/Wtq/Configuration/WtqSharedOptions.cs
+++ b/src/10-Core/Wtq/Configuration/WtqSharedOptions.cs
@@ -70,8 +70,7 @@ public abstract class WtqSharedOptions : IValidatableObject
 	/// <br/>
 	/// By setting this to <b>Never</b>, the app window size will be maintained.<br/>
 	/// <br/>
-	/// This is useful for cases when resizing an app's window heavily impacts its contents, such as when resizing a
-	/// window clears its contents (seems to be most common with Electron apps).
+	/// This is useful for cases when resizing an app's window heavily impacts its contents, such as when resizing a window clears its contents (seems to be most common with Electron apps).
 	/// </summary>
 	[DefaultValue(Resizing.Always)]
 	[Display(GroupName = Gn.Position, Name = "Resize app window")]

--- a/src/10-Core/Wtq/Services/IWtqAppRepo.cs
+++ b/src/10-Core/Wtq/Services/IWtqAppRepo.cs
@@ -11,19 +11,19 @@ public interface IWtqAppRepo
 	IEnumerable<WtqApp> GetAll();
 
 	/// <summary>
-	/// Returns the <see cref="WtqApp"/> instance for the <paramref name="name"/>, as specified in the app config (if any).
+	/// Returns the <see cref="WtqApp"/> instance for the <paramref name="name"/>, as specified in the app config.
 	/// </summary>
 	WtqApp? GetByName(
 		string name);
 
 	/// <summary>
-	/// Returns the <see cref="WtqApp"/> instance for the specified <paramref name="window"/> (if any).
+	/// Returns the <see cref="WtqApp"/> instance for the specified <paramref name="window"/>.
 	/// </summary>
 	WtqApp? GetByWindow(
 		WtqWindow window);
 
 	/// <summary>
-	/// Returns the app that is currently toggled onto the screen (if any).
+	/// Returns the app that is currently toggled onto the screen.
 	/// </summary>
 	WtqApp? GetOpen();
 
@@ -33,14 +33,14 @@ public interface IWtqAppRepo
 	IEnumerable<WtqApp> GetAllOpen();
 
 	/// <summary>
-	/// Returns the app that is currently toggled onto a screen that overlaps the given <paramref name="screenRect"/> (if any).
+	/// Returns the apps that are currently toggled onto a screen that overlaps the given <paramref name="screenRect"/>.
 	/// Used for per-screen app management in multi-monitor setups.
 	/// </summary>
-	WtqApp? GetOpenOnScreen(
+	IEnumerable<WtqApp> GetOpenOnScreen(
 		Rectangle screenRect);
 
 	/// <summary>
-	/// Returns the "primary" app, currently just the first one in the settings list (if any).
+	/// Returns the "primary" app, currently just the first one in the settings list.
 	/// </summary>
 	WtqApp? GetPrimary();
 }

--- a/src/10-Core/Wtq/Services/IWtqAppRepo.cs
+++ b/src/10-Core/Wtq/Services/IWtqAppRepo.cs
@@ -28,6 +28,18 @@ public interface IWtqAppRepo
 	WtqApp? GetOpen();
 
 	/// <summary>
+	/// Returns all apps that are currently toggled onto the screen.
+	/// </summary>
+	IEnumerable<WtqApp> GetAllOpen();
+
+	/// <summary>
+	/// Returns the app that is currently toggled onto a screen that overlaps the given <paramref name="screenRect"/> (if any).
+	/// Used for per-screen app management in multi-monitor setups.
+	/// </summary>
+	WtqApp? GetOpenOnScreen(
+		Rectangle screenRect);
+
+	/// <summary>
 	/// Returns the "primary" app, currently just the first one in the settings list (if any).
 	/// </summary>
 	WtqApp? GetPrimary();

--- a/src/10-Core/Wtq/Services/WtqAppRepo.cs
+++ b/src/10-Core/Wtq/Services/WtqAppRepo.cs
@@ -93,9 +93,9 @@ public sealed class WtqAppRepo : WtqHostedService, IWtqAppRepo
 	}
 
 	/// <inheritdoc/>
-	public WtqApp? GetOpenOnScreen(Rectangle screenRect)
+	public IEnumerable<WtqApp> GetOpenOnScreen(Rectangle screenRect)
 	{
-		return _apps.Values.FirstOrDefault(a =>
+		return _apps.Values.Where(a =>
 			a is { IsAttached: true, IsOpen: true } &&
 			a.CurrentScreenRect.HasValue &&
 			a.CurrentScreenRect.Value.IntersectsWith(screenRect));

--- a/src/10-Core/Wtq/Services/WtqAppRepo.cs
+++ b/src/10-Core/Wtq/Services/WtqAppRepo.cs
@@ -87,6 +87,21 @@ public sealed class WtqAppRepo : WtqHostedService, IWtqAppRepo
 	}
 
 	/// <inheritdoc/>
+	public IEnumerable<WtqApp> GetAllOpen()
+	{
+		return _apps.Values.Where(a => a is { IsAttached: true, IsOpen: true });
+	}
+
+	/// <inheritdoc/>
+	public WtqApp? GetOpenOnScreen(Rectangle screenRect)
+	{
+		return _apps.Values.FirstOrDefault(a =>
+			a is { IsAttached: true, IsOpen: true } &&
+			a.CurrentScreenRect.HasValue &&
+			a.CurrentScreenRect.Value.IntersectsWith(screenRect));
+	}
+
+	/// <inheritdoc/>
 	public WtqApp? GetPrimary()
 	{
 		return _apps.Values.FirstOrDefault();

--- a/src/10-Core/Wtq/WtqApp.cs
+++ b/src/10-Core/Wtq/WtqApp.cs
@@ -66,6 +66,12 @@ public sealed class WtqApp : IAsyncDisposable
 	public WtqAppOptions Options => _optionsAccessor();
 
 	/// <summary>
+	/// The screen rectangle that this app is currently displayed on, or null if the app is toggled off.<br/>
+	/// Used to track per-screen open state for multi-monitor setups.
+	/// </summary>
+	public Rectangle? CurrentScreenRect { get; set; }
+
+	/// <summary>
 	/// The <see cref="WtqWindow"/> that is tracked by this app (if any).
 	/// </summary>
 	public WtqWindow? Window { get; private set; }
@@ -81,6 +87,7 @@ public sealed class WtqApp : IAsyncDisposable
 		}
 
 		IsOpen = false;
+		CurrentScreenRect = null;
 
 		if (!IsAttached)
 		{
@@ -206,6 +213,9 @@ public sealed class WtqApp : IAsyncDisposable
 
 		// Move app onto screen.
 		await _toggler.ToggleOnAsync(this, mods).NoCtx();
+
+		// Track which screen this app is now displayed on.
+		CurrentScreenRect = await GetScreenRectAsync().NoCtx();
 
 		return true;
 	}

--- a/src/10-Core/Wtq/WtqService.cs
+++ b/src/10-Core/Wtq/WtqService.cs
@@ -11,7 +11,7 @@ public sealed class WtqService : WtqHostedService
 	private readonly ILogger _log;
 	private readonly IWtqAppRepo _appRepo;
 	private readonly IWtqBus _bus;
-	private readonly IWtqScreenInfoProvider _screenInfoProvider;
+	private readonly IWtqTargetScreenRectProvider _targetScreenRectProvider;
 	private readonly IOptionsMonitor<WtqOptions> _opts;
 	private readonly WtqSemaphoreSlim _lock = new(1, 1);
 
@@ -21,13 +21,13 @@ public sealed class WtqService : WtqHostedService
 		ILogger<WtqService> log,
 		IWtqAppRepo appRepo,
 		IWtqBus bus,
-		IWtqScreenInfoProvider screenInfoProvider,
+		IWtqTargetScreenRectProvider targetScreenRectProvider,
 		IOptionsMonitor<WtqOptions> opts)
 	{
 		_log = Guard.Against.Null(log);
 		_appRepo = Guard.Against.Null(appRepo);
 		_bus = Guard.Against.Null(bus);
-		_screenInfoProvider = Guard.Against.Null(screenInfoProvider);
+		_targetScreenRectProvider = Guard.Against.Null(targetScreenRectProvider);
 		_opts = Guard.Against.Null(opts);
 
 		_bus.OnEvent<WtqAppToggledEvent>(OnAppToggledEventAsync);
@@ -85,19 +85,29 @@ public sealed class WtqService : WtqHostedService
 			if (perScreen)
 			{
 				// Per-screen mode: only close apps on the same screen as the target.
-				var targetScreen = await _screenInfoProvider.GetScreenWithCursorAsync().NoCtx();
+				// Use the target screen rect provider so the "same screen" determination
+				// respects the app's PreferMonitor setting (Primary, AtIndex, WithCursor).
+				var targetScreen = await _targetScreenRectProvider.GetTargetScreenRectAsync(app.Options).NoCtx();
 
-				var openOnScreen = _appRepo.GetOpenOnScreen(targetScreen);
-				if (openOnScreen != null && openOnScreen != app)
+				// Close all open apps on the same screen (handles edge cases where
+				// multiple apps end up on one screen due to stale or missing state).
+				var openOnScreen = _appRepo.GetOpenOnScreen(targetScreen)
+					.Where(a => a != app)
+					.ToList();
+
+				if (openOnScreen.Count > 0)
 				{
-					_log.LogInformation(
-						"Closing app '{AppClosing}' on same screen, opening app '{AppOpening}'",
-						openOnScreen,
-						app);
+					foreach (var toClose in openOnScreen)
+					{
+						_log.LogInformation(
+							"Closing app '{AppClosing}' on same screen, opening app '{AppOpening}'",
+							toClose,
+							app);
 
-					_bus.Publish(new WtqAppToggledOffEvent(openOnScreen.Name, true));
+						_bus.Publish(new WtqAppToggledOffEvent(toClose.Name, true));
 
-					await openOnScreen.CloseAsync(ToggleModifiers.SwitchingApps).NoCtx();
+						await toClose.CloseAsync(ToggleModifiers.SwitchingApps).NoCtx();
+					}
 
 					_bus.Publish(new WtqAppToggledOnEvent(app.Name, true));
 

--- a/src/10-Core/Wtq/WtqService.cs
+++ b/src/10-Core/Wtq/WtqService.cs
@@ -11,6 +11,8 @@ public sealed class WtqService : WtqHostedService
 	private readonly ILogger _log;
 	private readonly IWtqAppRepo _appRepo;
 	private readonly IWtqBus _bus;
+	private readonly IWtqScreenInfoProvider _screenInfoProvider;
+	private readonly IOptionsMonitor<WtqOptions> _opts;
 	private readonly WtqSemaphoreSlim _lock = new(1, 1);
 
 	private WtqWindow? _lastNonWtqWindow;
@@ -18,11 +20,15 @@ public sealed class WtqService : WtqHostedService
 	public WtqService(
 		ILogger<WtqService> log,
 		IWtqAppRepo appRepo,
-		IWtqBus bus)
+		IWtqBus bus,
+		IWtqScreenInfoProvider screenInfoProvider,
+		IOptionsMonitor<WtqOptions> opts)
 	{
 		_log = Guard.Against.Null(log);
 		_appRepo = Guard.Against.Null(appRepo);
 		_bus = Guard.Against.Null(bus);
+		_screenInfoProvider = Guard.Against.Null(screenInfoProvider);
+		_opts = Guard.Against.Null(opts);
 
 		_bus.OnEvent<WtqAppToggledEvent>(OnAppToggledEventAsync);
 		_bus.OnEvent<WtqWindowFocusChangedEvent>(OnWindowFocusChangedEventAsync);
@@ -58,24 +64,8 @@ public sealed class WtqService : WtqHostedService
 		// Wait for service-wide lock.
 		using var l = await _lock.WaitOneSecondAsync().NoCtx();
 
-		// "Switching apps"
-		// If a previously toggled app (that is not the to-be-toggled app) is still open, close it first.
-		var open = _appRepo.GetOpen();
-		if (open != null && open != app)
-		{
-			_log.LogInformation("Closing app '{AppClosing}', opening app '{AppOpening}'", open, app);
+		var perScreen = _opts.CurrentValue.FeatureFlags?.PerScreenApps ?? true;
 
-			_bus.Publish(new WtqAppToggledOffEvent(open.Name, true));
-
-			await open.CloseAsync(ToggleModifiers.SwitchingApps).NoCtx();
-
-			_bus.Publish(new WtqAppToggledOnEvent(app.Name, true));
-
-			await app.OpenAsync(ToggleModifiers.SwitchingApps).NoCtx();
-			return;
-		}
-
-		// "Toggling app"
 		if (app.IsOpen)
 		{
 			// Toggle OFF
@@ -92,12 +82,61 @@ public sealed class WtqService : WtqHostedService
 		else
 		{
 			// Toggle ON
-			_log.LogInformation("Opening previously closed app '{App}'", app);
+			if (perScreen)
+			{
+				// Per-screen mode: only close apps on the same screen as the target.
+				var targetScreen = await _screenInfoProvider.GetScreenWithCursorAsync().NoCtx();
 
-			_bus.Publish(new WtqAppToggledOnEvent(app.Name, false));
+				var openOnScreen = _appRepo.GetOpenOnScreen(targetScreen);
+				if (openOnScreen != null && openOnScreen != app)
+				{
+					_log.LogInformation(
+						"Closing app '{AppClosing}' on same screen, opening app '{AppOpening}'",
+						openOnScreen,
+						app);
 
-			// Open app.
-			await app.OpenAsync().NoCtx();
+					_bus.Publish(new WtqAppToggledOffEvent(openOnScreen.Name, true));
+
+					await openOnScreen.CloseAsync(ToggleModifiers.SwitchingApps).NoCtx();
+
+					_bus.Publish(new WtqAppToggledOnEvent(app.Name, true));
+
+					await app.OpenAsync(ToggleModifiers.SwitchingApps).NoCtx();
+				}
+				else
+				{
+					_log.LogInformation("Opening previously closed app '{App}'", app);
+
+					_bus.Publish(new WtqAppToggledOnEvent(app.Name, false));
+
+					await app.OpenAsync().NoCtx();
+				}
+			}
+			else
+			{
+				// Legacy mode: close any open app globally before opening the new one.
+				var open = _appRepo.GetOpen();
+				if (open != null && open != app)
+				{
+					_log.LogInformation("Closing app '{AppClosing}', opening app '{AppOpening}'", open, app);
+
+					_bus.Publish(new WtqAppToggledOffEvent(open.Name, true));
+
+					await open.CloseAsync(ToggleModifiers.SwitchingApps).NoCtx();
+
+					_bus.Publish(new WtqAppToggledOnEvent(app.Name, true));
+
+					await app.OpenAsync(ToggleModifiers.SwitchingApps).NoCtx();
+				}
+				else
+				{
+					_log.LogInformation("Opening previously closed app '{App}'", app);
+
+					_bus.Publish(new WtqAppToggledOnEvent(app.Name, false));
+
+					await app.OpenAsync().NoCtx();
+				}
+			}
 		}
 	}
 

--- a/src/20-Services/Wtq.Services.UI/Pages/GlobalSettings/_Index.razor
+++ b/src/20-Services/Wtq.Services.UI/Pages/GlobalSettings/_Index.razor
@@ -36,6 +36,7 @@
 	private void Reload()
 	{
 		GlobalOpts = WtqOpts.CurrentValue.JsonDeepClone();
+		GlobalOpts.FeatureFlags ??= new FeatureFlags();
 	}
 
 }

--- a/src/20-Services/Wtq.Services.UI/Pages/GlobalSettings/_Index.razor
+++ b/src/20-Services/Wtq.Services.UI/Pages/GlobalSettings/_Index.razor
@@ -87,9 +87,6 @@
 		<RadzenFieldset Text="Behavior">
 			<RadzenStack Gap="1rem">
 
-				<!-- Per-screen apps -->
-				<WtqSettingCheckBox					TProperty="bool?"					Get="() => GlobalOpts.FeatureFlags!.PerScreenApps"	Set="v => GlobalOpts.FeatureFlags!.PerScreenApps = v ?? true"	Default="() => (bool?)true" />
-
 				<!-- Always on top -->
 				<WtqSettingCheckBox					TProperty="bool?"					Get="() => GlobalOpts.AlwaysOnTop"					Set="v => GlobalOpts.AlwaysOnTop = v"					Default="() => GlobalOpts.AlwaysOnTop" />
 
@@ -131,6 +128,9 @@
 
 		<RadzenFieldset Text="Monitor">
 			<RadzenStack Gap="1rem">
+
+				<!-- Per-screen apps -->
+				<WtqSettingCheckBox					TProperty="bool?"					Get="() => GlobalOpts.FeatureFlags!.PerScreenApps"	Set="v => GlobalOpts.FeatureFlags!.PerScreenApps = v ?? true"	Default="() => (bool?)true" />
 
 				<!-- Prefer monitor -->
 				<WtqSettingRadio					TProperty="PreferMonitor"			Get="() => GlobalOpts.PreferMonitor"				Set="v => GlobalOpts.PreferMonitor = v"					Default="() => GlobalOpts.PreferMonitor" />

--- a/src/20-Services/Wtq.Services.UI/Pages/GlobalSettings/_Index.razor
+++ b/src/20-Services/Wtq.Services.UI/Pages/GlobalSettings/_Index.razor
@@ -86,6 +86,9 @@
 		<RadzenFieldset Text="Behavior">
 			<RadzenStack Gap="1rem">
 
+				<!-- Per-screen apps -->
+				<WtqSettingCheckBox					TProperty="bool?"					Get="() => GlobalOpts.FeatureFlags!.PerScreenApps"	Set="v => GlobalOpts.FeatureFlags!.PerScreenApps = v ?? true"	Default="() => (bool?)true" />
+
 				<!-- Always on top -->
 				<WtqSettingCheckBox					TProperty="bool?"					Get="() => GlobalOpts.AlwaysOnTop"					Set="v => GlobalOpts.AlwaysOnTop = v"					Default="() => GlobalOpts.AlwaysOnTop" />
 


### PR DESCRIPTION
## Summary

Allow up to one WTQ app open per screen simultaneously. When activating a WTQ app on a screen, only close apps on that same screen — apps on different screens remain open.

Previously, toggling any app would close whatever app was currently open globally, regardless of which screen it was on. This made multi-monitor workflows frustrating: toggling a terminal on your secondary monitor would dismiss the terminal on your primary monitor.

## Changes

### Core Logic (`WtqService.cs`)
- `OnAppToggledEventAsync` now checks whether `PerScreenApps` is enabled
- When enabled, calls `GetOpenOnScreen(screenRect)` instead of `GetOpen()`, so only apps on the same screen are closed before opening the new one
- Falls back to the original single-app-global behavior when the feature flag is off

### Screen Tracking
- `WtqApp.CurrentScreenRect` — set to the screen rectangle when the app opens, cleared when it closes
- `WtqAppToggledEvent.ScreenRect` — carried from the hotkey handler (gets screen with cursor) through to the service layer

### Repository
- `IWtqAppRepo.GetAllOpen()` / `GetOpenOnScreen(Rectangle)` — new methods on the repo interface and implementation
- Screen matching uses `Rectangle.IntersectsWith` to compare screen rects

### Feature Flag
- `FeatureFlags.PerScreenApps` — defaults to `true` (new behavior is opt-out)
- Toggle is in the **Monitor** section of Global Settings GUI

### Tests
- `WtqAppRepoPerScreenTest` — unit tests for per-screen open/close behavior

## Files Changed (8 files)

| File | Change |
|------|--------|
| `FeatureFlags.cs` | Add `PerScreenApps` flag (default `true`) |
| `WtqApp.cs` | Add `CurrentScreenRect` property |
| `IWtqAppRepo.cs` | Add `GetAllOpen()` and `GetOpenOnScreen()` |
| `WtqAppRepo.cs` | Implement screen-matching logic |
| `WtqService.cs` | Refactor `OnAppToggledEventAsync` for per-screen logic |
| `WtqAppToggledEvent.cs` | Add `ScreenRect` property |
| `WtqHotkeyService.cs` | Pass screen rect to toggle event |
| `_Index.razor` (Global) | Add PerScreenApps checkbox in Monitor section |

## Testing

- 189/190 unit tests pass (1 pre-existing skip)
- Manual testing on dual-monitor setup: toggling on screen 2 leaves screen 1 apps open and vice versa