### PR TITLE
bugfix: wtq dies when attempting to handle an app in a broken state, on startup

### DIFF
--- a/src/10-Core/Wtq/WtqApp.cs
+++ b/src/10-Core/Wtq/WtqApp.cs
@@ -324,6 +324,9 @@ public sealed class WtqApp : IAsyncDisposable
 
 		Window = window;
 
+		// Ask window to update its state.
+		await window.UpdateAsync().NoCtx();
+
 		// Move the window off the screen ASAP (e.g. without animating).
 		await CloseAsync(ToggleModifiers.Instant).NoCtx();
 	}

--- a/src/20-Services/Wtq.Services.Win32/Win32WtqWindow.cs
+++ b/src/20-Services/Wtq.Services.Win32/Win32WtqWindow.cs
@@ -208,7 +208,8 @@ public sealed class Win32WtqWindow : WtqWindow
 	{
 		if (size.Width < 200 || size.Height < 200)
 		{
-			throw new InvalidOperationException($"Attempted to set window size to something under 200x200, which can mess up windows.");
+			_log.LogWarning("Attempted to set window size to something under 200x200, which can mess up windows.");
+			return;
 		}
 
 		// Get current window rect.

--- a/src/30-Host/Wtq.Host.Windows/wtq.jsonc
+++ b/src/30-Host/Wtq.Host.Windows/wtq.jsonc
@@ -18,13 +18,14 @@
 
 		// Explorer
 		{
-			"Name": "Explorer",
+			"Name": "KeePassXC",
 			"Hotkeys": [{ "Modifiers": "Control", "KeyChar": "2" }, { "Modifiers": "Control,Alt", "KeyChar": "ArrowUp" }],
 			"FileName": "keepassxc",
 			"TaskbarIconVisibility": "WhenAppVisible",
 			"HideOnFocusLost": "Never",
 			"Exclusive": "Never",
-			"HorizontalAlign": "Right"
+			"HorizontalAlign": "Right",
+			"MainWindow": "MainWindowOnly"
 		}
 	],
 

--- a/src/30-Host/Wtq.Host.Windows/wtq.jsonc
+++ b/src/30-Host/Wtq.Host.Windows/wtq.jsonc
@@ -18,14 +18,13 @@
 
 		// Explorer
 		{
-			"Name": "KeePassXC",
+			"Name": "Explorer",
 			"Hotkeys": [{ "Modifiers": "Control", "KeyChar": "2" }, { "Modifiers": "Control,Alt", "KeyChar": "ArrowUp" }],
 			"FileName": "keepassxc",
 			"TaskbarIconVisibility": "WhenAppVisible",
 			"HideOnFocusLost": "Never",
 			"Exclusive": "Never",
-			"HorizontalAlign": "Right",
-			"MainWindow": "MainWindowOnly"
+			"HorizontalAlign": "Right"
 		}
 	],
 


### PR DESCRIPTION
Win32WtqWindow.SetSizeAsync is called when WTQ starts, but can throw in some cases, causing WTQ to crash.

Changed said method to log a warning instead of throwing, as that's more in line with the rest of the class anyway (throwing happens one level deeper, in Win32.cs).